### PR TITLE
add applets

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,4 @@
+from jax.base.applets.jax_applet import JaxApplet
 from jax.base.environments.jax_environment import JaxEnvironment
 from jax.base.environments.sinara_environment import SinaraEnvironment
 from jax.base.experiments.jax_experiment import JaxExperiment

--- a/base/applets/jax_applet.py
+++ b/base/applets/jax_applet.py
@@ -1,0 +1,92 @@
+import asyncio
+import threading
+from PyQt5 import QtCore
+
+
+__all__ = ["JaxApplet"]
+
+
+class JaxApplet(QtCore.QObject):
+    """Base class for all applets.
+
+    LabRAD cannot be run in the main thread as twisted asyncioreactor does not support the
+    WindowsProactorEventLoop, which ARTIQ requires. All LabRAD calls need to be done in a
+    separate thread.
+    """
+    @classmethod
+    def add_labrad_ip_argument(self, applet, default_ip="127.0.0.1"):
+        """Adds an argument to set the LabRAD IP address to connect to.
+
+        Args:
+            applet: artiq.applets.simple.SimpleApplet object.
+            default_ip: str, default IP addres to connect to. Default "127.0.0.1" (local computer).
+        """
+        applet.argparser.add_argument("--ip", type=str, default=default_ip,
+                                      help="LabRAD manager IP address to connect to")
+
+    def __init__(self, **kwds):
+        super().__init__(**kwds)
+        self._labrad_loop = None
+
+    def connect_to_labrad(self, ip="127.0.0.1"):
+        """Connects to labrad in another thread (non-blocking).
+
+        This function should be called by derived classes.
+        After the connection finishes, self.labrad_connected will be called.
+        The event loop in artiq.applets.simple.SimpleApplet is not compatible with asyncioreactor.
+        """
+        def worker():
+            import selectors
+            selector = selectors.SelectSelector()
+            self._labrad_loop = asyncio.SelectorEventLoop(selector)
+            asyncio.set_event_loop(self._labrad_loop)
+
+            from twisted.internet import asyncioreactor
+            asyncioreactor.install(self._labrad_loop)
+
+            self._labrad_loop.create_task(self.labrad_worker(ip))
+            self._labrad_loop.run_forever()
+
+        self._labrad_thread = threading.Thread(target=worker)
+        self._labrad_thread.start()
+
+    def data_changed(self, data, mods):
+        """We don't use ARTIQ dataset manager so this function is not used."""
+        pass
+
+    async def labrad_worker(self, ip):
+        """Worker to connect to labrad in self._labrad_loop event loop."""
+        from pydux.lib.control.clients.connection_asyncio import ConnectionAsyncio
+        self.cxn = ConnectionAsyncio()
+        await self.cxn.connect(ip)
+        await self.labrad_connected()
+        while True:  # required for the event loop to keep handling events.
+            short_time = 0.01
+            await asyncio.sleep(short_time)
+
+    async def labrad_connected(self):
+        """Called when the labrad connection self.cxn is set.
+
+        Should be implemented by derived classes.
+        """
+        raise NotImplementedError("This function must be overriden by derived classes.")
+
+    def run_in_labrad_loop(self, func):
+        """Wrapper for an async function to run in self._labrad_loop.
+
+        All code that uses labrad needs to be run in the labrad event loop.
+
+        Args:
+            func: async function to control labrad.
+
+        Returns:
+            func_ensured_future: sync function.
+        """
+        def func_ensured_future(*args, **kwargs):
+            asyncio.ensure_future(func(*args, **kwargs), loop=self._labrad_loop)
+
+        return func_ensured_future
+
+    def closeEvent(self, event):
+        if self._labrad_loop is not None:
+            self._labrad_loop.stop()

--- a/base/environments/jax_environment.py
+++ b/base/environments/jax_environment.py
@@ -1,10 +1,8 @@
 import threading
-import labrad
 from sipyco import pyon
 from artiq.experiment import *
 from jax.util.parameter_group import ParameterGroup
 from jax.util.drift_tracker import DriftTracker
-from jax.util.labrad import remove_labrad_units
 
 
 __all__ = ["JaxEnvironment"]
@@ -33,6 +31,7 @@ class JaxEnvironment(HasEnvironment):
         self._is_dataset_open = False
 
     def _connect_labrad(self):
+        import labrad
         self.cxn = labrad.connect()
         try:
             self.dv = self.cxn.vault
@@ -278,6 +277,8 @@ class JaxEnvironment(HasEnvironment):
 
         Also saves all parameters to the data file.
         """
+        from jax.util.labrad import remove_labrad_units
+
         params = {}
         params_full = {}
         pb = self.cxn.parameter_database

--- a/tools/applets/dds.py
+++ b/tools/applets/dds.py
@@ -1,0 +1,97 @@
+import time
+from sipyco import pyon
+from PyQt5 import QtGui, QtWidgets, QtCore
+from artiq.applets.simple import SimpleApplet
+from jax import JaxApplet
+from jax.tools.applets.dds_channel import DDSChannel, DDSParameters
+
+
+class DDS(QtWidgets.QWidget, JaxApplet):
+    # signal emitted after getting DDS parameters.
+    # a signal is needed to run self.initialize_channels on the default thread.
+    # widgets can only be created in the default thread.
+    do_initialize = QtCore.pyqtSignal()
+
+    def __init__(self, args, **kwds):
+        super().__init__(**kwds)
+        self.setDisabled(True)  # start with the applet disabled, until artiq server is connected.
+        self.do_initialize.connect(self.initialize_channels)
+
+        self.initialize_gui()
+        # connects to LabRAD in a different thread, and calls self.labrad_connected when finished.
+        self.connect_to_labrad(args.ip)
+
+    def initialize_gui(self):
+        font = QtGui.QFont("Arial", 15)
+        layout = QtWidgets.QGridLayout()
+        self.grid = QtWidgets.QListWidget()
+        self.grid.setFlow(QtWidgets.QListView.LeftToRight)
+        self.grid.setResizeMode(QtWidgets.QListView.Adjust)
+        self.grid.setViewMode(QtWidgets.QListView.IconMode)
+        layout.addWidget(self.grid)
+        self.setLayout(layout)
+
+    async def labrad_connected(self):
+        """Called when LabRAD is connected."""
+        await self.artiq_connected()
+        await self.setup_cxn_listeners()
+
+    async def artiq_connected(self):
+        self.artiq = self.cxn.get_server("artiq")
+        self.params = await self.artiq.get_dds_parameters()
+        self.params = pyon.decode(self.params)
+        self.do_initialize.emit()  # tells the main thread that it can populate the DDS channels.
+
+        DDS_CHANGE = 124890
+        await self.artiq.on_dds_change(DDS_CHANGE)
+        self.artiq.addListener(listener=self._dds_changed, source=None, ID=DDS_CHANGE)
+        self.setDisabled(False)
+
+    @QtCore.pyqtSlot()
+    def initialize_channels(self):
+        self.channels = {}
+        for channel in self.params:
+            cpld = "Not implemented"  # current code does not query the cpld name.
+            frequency = self.params[channel][0]
+            phase = self.params[channel][1]
+            amp = self.params[channel][2]
+            att = self.params[channel][3]
+            state = (self.params[channel][4] > 0)
+            channel_param = DDSParameters(self, channel, cpld, amp, att, frequency, phase, state)
+            channel_widget = DDSChannel(channel_param, self)
+            self.channels[channel] = channel_widget
+            self._still_looping = False
+
+            item = QtWidgets.QListWidgetItem()
+            item.setSizeHint(channel_widget.sizeHint())
+            self.grid.setGridSize(channel_widget.sizeHint())
+            self.grid.addItem(item)
+            self.grid.setItemWidget(item, channel_widget)
+
+    async def setup_cxn_listeners(self):
+        self.cxn.add_on_connect("artiq", self.run_in_labrad_loop(self.artiq_connected))
+        self.cxn.add_on_disconnect("artiq", self.artiq_disconnected)
+
+    def artiq_disconnected(self):
+        self.setDisabled(True)
+
+    def _dds_changed(self, signal, value):
+        channel, attribute, val = value
+        if attribute == "frequency":
+            self.channels[channel].on_monitor_freq_changed(val)
+        elif attribute == "amplitude":
+            self.channels[channel].on_monitor_amp_changed(val)
+        elif attribute == "attenuation":
+            self.channels[channel].on_monitor_att_changed(val)
+        elif attribute == "state":
+            self.channels[channel].on_monitor_switch_changed(val > 0.)
+
+
+def main():
+    applet = SimpleApplet(DDS)
+    DDS.add_labrad_ip_argument(applet)  # adds IP address as an argument.
+    applet.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/applets/dds_channel.py
+++ b/tools/applets/dds_channel.py
@@ -1,0 +1,249 @@
+from PyQt5 import QtWidgets, QtGui, QtCore
+
+
+class DDSParameters:
+    """Stores DDS parameters and calls the artiq server when changes are made."""
+    def __init__(self, parent, channel, cpld, amplitude, att, frequency, phase, state):
+        self.parent = parent
+        self.channel = channel
+        self.cpld = cpld
+        self._amplitude = amplitude
+        self._att = att
+        self._frequency = frequency
+        self._phase = phase
+        self._state = state
+
+    @property
+    def amplitude(self):
+        return self._amplitude
+
+    @property
+    def att(self):
+        return self._att
+
+    @property
+    def frequency(self):
+        return self._frequency
+
+    @property
+    def phase(self):
+        return self._phase
+
+    @property
+    def state(self):
+        return self._state
+
+    def set_amplitude(self, value, update=True):
+        if value != self._amplitude and update:
+            command = (self.channel, "amplitude", value)
+            self._change_dds(command)
+        self._amplitude = value
+
+    def set_att(self, value, update=True):
+        if value != self._att and update:
+            command = (self.channel, "att", value)
+            self._change_dds(command)
+        self._att = value
+
+    def set_frequency(self, value, update=True):
+        if value != self._frequency and update:
+            command = (self.channel, "frequency", value)
+            self._change_dds(command)
+        self._frequency = value
+
+    def set_phase(self, value, update=True):
+        if value != self._phase and update:
+            command = (self.channel, "phase", value)
+            self._change_dds(command)
+        self._phase = value
+
+    def set_state(self, value, update=True):
+        if value != self._state and update:
+            if value:
+                value_set = 1.
+            else:
+                value_set = -1.
+            command = (self.channel, "state", value_set)
+            self._change_dds(command)
+        self._state = value
+
+    def _change_dds(self, command):
+        async def worker(self, command):
+            await self.parent.artiq.set_dds(command)
+
+        self.parent.run_in_labrad_loop(worker)(self, command)
+
+
+class DDSDetail(QtWidgets.QDialog):
+    """A dialog showing details for a channel."""
+    def __init__(self, dds_parameters, parent=None):
+        self.dds_parameters = dds_parameters
+        super().__init__(
+            parent,
+            QtCore.Qt.WindowSystemMenuHint | QtCore.Qt.WindowTitleHint
+            | QtCore.Qt.WindowCloseButtonHint)
+        self.setWindowTitle(dds_parameters.channel)
+        self.initialize_gui()
+        self.setup_gui_listeners()
+
+    def initialize_gui(self):
+        grid = QtWidgets.QGridLayout()
+        self.setLayout(grid)
+        labelfont = QtGui.QFont('Arial', 10)
+        spinboxfont = QtGui.QFont('Arial', 15)
+
+        label = QtWidgets.QLabel(f"CPLD: {self.dds_parameters.cpld}")
+        label.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
+                            QtWidgets.QSizePolicy.Fixed)
+        label.setFont(labelfont)
+        grid.addWidget(label, 0, 0)
+
+        label = QtWidgets.QLabel("Att (dB)")
+        label.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
+                            QtWidgets.QSizePolicy.Fixed)
+        label.setFont(labelfont)
+        grid.addWidget(label, 1, 0)
+
+        self.att_box = QtWidgets.QDoubleSpinBox()
+        self.att_box.setDecimals(1)
+        self.att_box.setMinimum(-31.5)
+        self.att_box.setMaximum(0.)
+        self.att_box.setSingleStep(0.5)
+        self.att_box.setFont(spinboxfont)
+        self.att_box.setKeyboardTracking(False)
+        self.att_box.setValue(-self.dds_parameters.att)
+        grid.addWidget(self.att_box, 2, 0)
+
+    def setup_gui_listeners(self):
+        self.att_box.valueChanged.connect(self.on_widget_att_changed)
+
+    def on_widget_att_changed(self, val):
+        self.dds_parameters.set_att(-val)
+
+
+class DDSChannel(QtWidgets.QGroupBox):
+    """GUI for a DDS channel."""
+    def __init__(self, dds_parameters, parent=None):
+        self.dds_parameters = dds_parameters
+        super().__init__(parent)
+        self.initialize_gui()
+        self.setup_gui_listeners()
+
+    def initialize_gui(self):
+        titlefont = QtGui.QFont('Arial', 16)
+        labelfont = QtGui.QFont('Arial', 10)
+        buttonfont = QtGui.QFont('Arial', 15)
+        spinboxfont = QtGui.QFont('Arial', 15)
+
+        grid = QtWidgets.QGridLayout()
+        self.setLayout(grid)
+        self.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
+                           QtWidgets.QSizePolicy.Fixed)
+
+        label = QtWidgets.QLabel(self.dds_parameters.channel)
+        label.setSizePolicy(QtWidgets.QSizePolicy.Expanding,
+                            QtWidgets.QSizePolicy.Fixed)
+        label.setAlignment(QtCore.Qt.AlignHCenter)
+        label.setFont(titlefont)
+        grid.addWidget(label, 0, 0, 1, 3)
+
+        label = QtWidgets.QLabel("Frequency (MHz)")
+        label.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
+                            QtWidgets.QSizePolicy.Fixed)
+        label.setFont(labelfont)
+        grid.addWidget(label, 1, 0)
+
+        label = QtWidgets.QLabel("Amplitude")
+        label.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
+                            QtWidgets.QSizePolicy.Fixed)
+        label.setFont(labelfont)
+        grid.addWidget(label, 1, 1)
+
+        self.freq_box = QtWidgets.QDoubleSpinBox()
+        self.freq_box.setDecimals(3)
+        self.freq_box.setMinimum(1.0)
+        self.freq_box.setMaximum(500.0)
+        self.freq_box.setSingleStep(0.1)
+        self.freq_box.setFont(spinboxfont)
+        self.freq_box.setKeyboardTracking(False)
+        MHz_to_Hz = 1.e6
+        self.freq_box.setValue(self.dds_parameters.frequency / MHz_to_Hz)
+        grid.addWidget(self.freq_box, 2, 0)
+
+        self.amp_box = QtWidgets.QDoubleSpinBox()
+        self.amp_box.setDecimals(5)
+        self.amp_box.setMinimum(0.0)
+        self.amp_box.setMaximum(1.0)
+        self.amp_box.setSingleStep(0.01)
+        self.amp_box.setFont(spinboxfont)
+        self.amp_box.setSizePolicy(QtWidgets.QSizePolicy.Preferred,
+                                   QtWidgets.QSizePolicy.Preferred)
+        self.amp_box.setKeyboardTracking(False)
+        self.amp_box.setValue(self.dds_parameters.amplitude)
+        grid.addWidget(self.amp_box, 2, 1)
+
+        self.switch_button = QtWidgets.QPushButton("o")
+        self.switch_button.setFont(buttonfont)
+        self.switch_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
+                                         QtWidgets.QSizePolicy.Fixed)
+        self.switch_button.setCheckable(True)
+        if self.dds_parameters.state:
+            self.switch_button.setChecked(self.dds_parameters.state)
+            self.set_switch_button_text(self.dds_parameters.state)
+        grid.addWidget(self.switch_button, 2, 2)
+
+    def setup_gui_listeners(self):
+        self.freq_box.valueChanged.connect(self.on_widget_freq_changed)
+        self.amp_box.valueChanged.connect(self.on_widget_amp_changed)
+        self.switch_button.clicked.connect(self.on_widget_switch_changed)
+
+    def on_widget_freq_changed(self, val):
+        MHz_to_Hz = 1.e6
+        self.dds_parameters.set_frequency(val * MHz_to_Hz)
+
+    def on_widget_amp_changed(self, val):
+        self.dds_parameters.set_amplitude(val)
+
+    def on_widget_switch_changed(self, checked):
+        self.dds_parameters.set_state(checked)
+        self.set_switch_button_text(checked)
+
+    def on_monitor_freq_changed(self, val):
+        MHz_to_Hz = 1.e6
+        self.freq_box.blockSignals(True)
+        self.freq_box.setValue(val / MHz_to_Hz)
+        self.freq_box.blockSignals(False)
+        self.dds_parameters.set_frequency(val, False)
+
+    def on_monitor_amp_changed(self, val):
+        self.amp_box.blockSignals(True)
+        self.amp_box.setValue(val)
+        self.amp_box.blockSignals(False)
+        self.dds_parameters.set_amplitude(val, False)
+
+    def on_monitor_att_changed(self, val):
+        self.dds_parameters.set_att(val, False)
+
+    def on_monitor_switch_changed(self, checked):
+        self.switch_button.blockSignals(True)
+        self.switch_button.setChecked(checked)
+        self.switch_button.blockSignals(False)
+        self.set_switch_button_text(checked)
+        self.dds_parameters.set_state(checked, False)
+
+    def set_switch_button_text(self, checked):
+        if checked:
+            self.switch_button.setText("I")
+        else:
+            self.switch_button.setText("o")
+
+    def contextMenuEvent(self, event):
+        menu = QtWidgets.QMenu()
+        details_action = menu.addAction("Details")
+        action = menu.exec_(self.mapToGlobal(event.pos()))
+        if action == details_action:
+            self.show_details()
+
+    def show_details(self):
+        self.details = DDSDetail(self.dds_parameters, self)
+        self.details.exec_()

--- a/tools/applets/pmt.py
+++ b/tools/applets/pmt.py
@@ -1,0 +1,200 @@
+from PyQt5 import QtWidgets, QtCore
+from artiq.applets.simple import SimpleApplet
+from jax import JaxApplet
+
+
+class PMT(QtWidgets.QWidget, JaxApplet):
+    def __init__(self, args, **kwds):
+        super().__init__(**kwds)
+        self._dv_on = False
+        self._pmt_on = False
+        self.set_disable_state()
+
+        self._normal_mode_text = "Normal"
+        self._differential_mode_text = "Differential"
+        self._pmt_counts_dataset = "pmt.counts_kHz"
+
+        self.initialize_gui()
+        # connects to LabRAD in a different thread, and calls self.labrad_connected when finished.
+        self.connect_to_labrad(args.ip)
+
+    def set_disable_state(self):
+        if self._pmt_on and self._dv_on:
+            self.setDisabled(False)
+        else:
+            self.setDisabled(True)
+
+    def initialize_gui(self):
+        layout = QtWidgets.QGridLayout()
+        self.number = QtWidgets.QLCDNumber()
+        self.number.setDigitCount(4)
+        self.number.setSmallDecimalPoint(True)
+        layout.addWidget(self.number, 0, 1, 5, 1)
+
+        mode_label = QtWidgets.QLabel("Mode:")
+        mode_label.setAlignment(QtCore.Qt.AlignBottom)
+        layout.addWidget(mode_label, 0, 0)
+
+        self.mode_combobox = QtWidgets.QComboBox()
+        self.mode_combobox.addItem(self._normal_mode_text)
+        self.mode_combobox.addItem(self._differential_mode_text)
+        layout.addWidget(self.mode_combobox, 1, 0)
+
+        interval_label = QtWidgets.QLabel("Interval:")
+        interval_label.setAlignment(QtCore.Qt.AlignBottom)
+        layout.addWidget(interval_label, 2, 0)
+
+        self.interval_spinbox = QtWidgets.QDoubleSpinBox()
+        self.interval_spinbox.setSuffix(" s")
+        self.interval_spinbox.setSingleStep(0.1)
+        self.interval_spinbox.setDecimals(2)
+        layout.addWidget(self.interval_spinbox, 3, 0)
+
+        self.start_button = QtWidgets.QPushButton("Start")
+        self.start_button.setCheckable(True)
+        layout.addWidget(self.start_button, 4, 0)
+        self.setLayout(layout)
+
+    async def labrad_connected(self):
+        self.setup_gui_listeners()
+        await self.vault_connected()
+        await self.pmt_connected()
+        await self.setup_cxn_listeners()
+
+    async def vault_connected(self):
+        self.dv = self.cxn.get_server("vault")
+        self._dv_on = True
+        await self.dv.subscribe_to_shared_dataset(self._pmt_counts_dataset)
+        SHARED_DATA_CHANGE = 128936
+        await self.dv.on_shared_data_change(SHARED_DATA_CHANGE)
+        self.dv.addListener(listener=self._data_change, source=None, ID=SHARED_DATA_CHANGE)
+        self.set_disable_state()
+
+    async def pmt_connected(self):
+        self.pmt = self.cxn.get_server("pmt")
+        self._pmt_on = True
+        interval_range = await self.pmt.get_interval_range()
+        self.interval_spinbox.setRange(*interval_range)
+        interval = await self.pmt.get_interval()
+        self._set_pmt_interval(interval)
+        differential_mode = await self.pmt.is_differential_mode()
+        self._set_pmt_mode(differential_mode)
+        is_running = await self.pmt.is_running()
+        self._set_pmt_state(is_running)
+
+        NEW_MODE = 128937
+        await self.pmt.on_new_mode(NEW_MODE)
+        self.pmt.addListener(listener=self._new_pmt_mode, source=None, ID=NEW_MODE)
+        NEW_INTERVAL = 128938
+        await self.pmt.on_new_interval(NEW_INTERVAL)
+        self.pmt.addListener(listener=self._new_pmt_interval, source=None, ID=NEW_INTERVAL)
+        FILE_HALF_FULL = 128939
+        await self.pmt.on_file_half_full(FILE_HALF_FULL)
+        self.pmt.addListener(listener=self._file_half_full, source=None, ID=FILE_HALF_FULL)
+        AUTO_NEW_FILE = 128940
+        await self.pmt.on_auto_new_file(AUTO_NEW_FILE)
+        self.pmt.addListener(listener=self._auto_new_file, source=None, ID=AUTO_NEW_FILE)
+        self.set_disable_state()
+
+    async def setup_cxn_listeners(self):
+        self.cxn.add_on_connect("pmt", self.run_in_labrad_loop(self.pmt_connected))
+        self.cxn.add_on_disconnect("pmt", self.pmt_disconnected)
+
+        self.cxn.add_on_connect("vault", self.run_in_labrad_loop(self.vault_connected))
+        self.cxn.add_on_disconnect("vault", self.vault_disconnected)
+
+    def setup_gui_listeners(self):
+        self.start_button.toggled.connect(self.start_button_toggled)
+        self.mode_combobox.currentTextChanged.connect(self.mode_combobox_text_changed)
+        self.interval_spinbox.valueChanged.connect(self.interval_spinbox_value_changed)
+
+    def pmt_disconnected(self):
+        self._pmt_on = False
+        self.set_disable_state()
+
+    def vault_disconnected(self):
+        self._dv_on = False
+        self.set_disable_state()
+
+    def _data_change(self, signal, value):
+        if value[1] == self._pmt_counts_dataset:
+            self._set_number(value[2][0][0])
+
+    def _new_pmt_mode(self, signal, value):
+        self._set_pmt_mode(value)
+
+    def _new_pmt_interval(self, signal, value):
+        self._set_pmt_interval(value)
+
+    def _file_half_full(self, signal, value):
+        print("PMT file half full")
+
+    def _auto_new_file(self, signal, value):
+        print("New PMT file automatically created.")
+
+    def _set_number(self, counts):
+        self.number.display(counts)
+
+    def _set_pmt_interval(self, interval):
+        self.interval_spinbox.blockSignals(True)
+        self.interval_spinbox.setValue(interval)
+        self.interval_spinbox.blockSignals(False)
+
+    def _set_pmt_mode(self, is_differential_mode):
+        self.mode_combobox.blockSignals(True)
+        if is_differential_mode:
+            self.mode_combobox.setCurrentText(self._differential_mode_text)
+        else:
+            self.mode_combobox.setCurrentText(self._normal_mode_text)
+        self.mode_combobox.blockSignals(False)
+
+    def _set_pmt_state(self, is_running):
+        self.start_button.blockSignals(True)
+        self.start_button.setChecked(is_running)
+        if is_running:
+            self.start_button.setText("Stop")
+        else:
+            self.start_button.setText("Start")
+        self.start_button.blockSignals(False)
+
+    def start_button_toggled(self, checked):
+        async def _start_button_toggled(self, checked):
+            self._set_pmt_state(checked)
+            if checked:
+                await self.pmt.start()
+            else:
+                await self.pmt.stop()
+
+        self.run_in_labrad_loop(_start_button_toggled)(self, checked)
+
+    def start_button_toggled(self, checked):
+        async def _start_button_toggled(self, checked):
+            self._set_pmt_state(checked)
+            if checked:
+                await self.pmt.start()
+            else:
+                await self.pmt.stop()
+
+        self.run_in_labrad_loop(_start_button_toggled)(self, checked)
+
+    def mode_combobox_text_changed(self, text):
+        async def _mode_combobox_text_changed(self, text):
+            await self.pmt.set_mode(text == self._differential_mode_text)
+
+        self.run_in_labrad_loop(_mode_combobox_text_changed)(self, text)
+
+    def interval_spinbox_value_changed(self, value):
+        async def _interval_spinbox_value_changed(self, value):
+            await self.pmt.set_interval(value)
+
+        self.run_in_labrad_loop(_interval_spinbox_value_changed)(self, value)
+
+
+def main():
+    applet = SimpleApplet(PMT)
+    PMT.add_labrad_ip_argument(applet)  # adds IP address as an argument.
+    applet.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #10.

Adds a `JaxApplet` base class for applets, which handles the labrad connection.

Adds DDS and PMT applets.

Edits `jax_environment` to put labrad imports in functions rather than the beginning of the file. When an applet imports `jax` it also imports `jax_environment`. If `labrad` imports are in the beginning of the file, the applet imports `labrad` and therefore `twisted` before setting up the asyncio event loop which causes a problem.