### PR TITLE
turn off ddses after returning from another experiment

### DIFF
--- a/base/experiments/scan.py
+++ b/base/experiments/scan.py
@@ -36,6 +36,7 @@ class Scan(JaxExperiment):
                 if should_stop:
                     break
                 else:
+                    self.turn_off_all_ddses()
                     self.kernel_run()
         except Exception as e:
             raise e
@@ -44,7 +45,6 @@ class Scan(JaxExperiment):
 
     def host_startup(self):
         """Called at the start of self.run(). Can be overriden."""
-        self.turn_off_all_ddses()
         self.open_file()
         self._scans_finished = 0
 

--- a/examples/experiments/ex2_pulse_sequence.py
+++ b/examples/experiments/ex2_pulse_sequence.py
@@ -54,7 +54,6 @@ class PulseSequence(JaxExperiment, SinaraEnvironment):
 
     def run(self):
         try:
-            self.turn_off_all_ddses()
             self.repeats_done = 0  # tracks how many repeatitions have been done.
             self.open_file()  # opens up a file for writing data.
             # defines a instance variable that will be used in the kernel.
@@ -67,6 +66,7 @@ class PulseSequence(JaxExperiment, SinaraEnvironment):
                 if should_stop:
                     break
                 else:
+                    self.turn_off_all_ddses()
                     self.run_kernel()
         except Exception as e:
             raise e


### PR DESCRIPTION
Fixes a bug that 1d scans don't turn off DDSes after pausing and returning from another experiment