### PR TITLE
Applet config support and CustomListWidget remembers the last state

### DIFF
--- a/base/applets/jax_applet.py
+++ b/base/applets/jax_applet.py
@@ -1,6 +1,9 @@
+import os
 import asyncio
 import threading
+import pathlib
 from PyQt5 import QtCore
+from sipyco import pyon
 
 
 __all__ = ["JaxApplet"]
@@ -25,9 +28,50 @@ class JaxApplet(QtCore.QObject):
         applet.argparser.add_argument("--ip", type=str, default=default_ip,
                                       help="LabRAD manager IP address to connect to")
 
+    @classmethod
+    def add_id_argument(self, applet, default_id=""):
+        """Adds an argument to set the ID of the applet.
+
+        Applet ID is used to assign different config files to instances of a same applet class.
+
+        Args:
+            applet: artiq.applets.simple.SimpleApplet object.
+            default_id: str, default ID of the applet. Default "".
+        """
+        applet.argparser.add_argument("--id", type=str, default=default_id,
+                                      help="Configuration ID")
+
     def __init__(self, **kwds):
         super().__init__(**kwds)
         self._labrad_loop = None
+
+    def load_config_file(self, module_name, args):
+        """Loads the config file content into self.config.
+
+        Arguments:
+            module_name: str, applet module name.
+            args: command line arguments.
+        """
+        try:
+            ip = args.ip
+        except AttributeError:
+            ip = "none"
+        try:
+            id = args.id
+        except AttributeError:
+            id = ""
+        folder_name = os.path.join(os.path.expanduser('~'), ".jax", "applets")
+        pathlib.Path(folder_name).mkdir(parents=True, exist_ok=True)  # create the folder if it does not exist
+
+        self._config_file_path = os.path.join(folder_name, f"{module_name}_{ip}_{id}.pyon")
+        try:
+            self.config = pyon.load_file(self._config_file_path)
+        except FileNotFoundError:
+            self.config = {}
+
+    def save_config_file(self):
+        """Write self.config to the config file."""
+        pyon.store_file(self._config_file_path, self.config)
 
     def connect_to_labrad(self, ip="127.0.0.1"):
         """Connects to labrad in another thread (non-blocking).

--- a/base/applets/jax_applet.py
+++ b/base/applets/jax_applet.py
@@ -48,7 +48,7 @@ class JaxApplet(QtCore.QObject):
     def load_config_file(self, module_name, args):
         """Loads the config file content into self.config.
 
-        Arguments:
+        Args:
             module_name: str, applet module name.
             args: command line arguments.
         """
@@ -61,7 +61,8 @@ class JaxApplet(QtCore.QObject):
         except AttributeError:
             id = ""
         folder_name = os.path.join(os.path.expanduser('~'), ".jax", "applets")
-        pathlib.Path(folder_name).mkdir(parents=True, exist_ok=True)  # create the folder if it does not exist
+        # create the folder if it does not exist
+        pathlib.Path(folder_name).mkdir(parents=True, exist_ok=True)
 
         self._config_file_path = os.path.join(folder_name, f"{module_name}_{ip}_{id}.pyon")
         try:

--- a/tools/applets/dds.py
+++ b/tools/applets/dds.py
@@ -19,6 +19,7 @@ class DDS(QtWidgets.QWidget, JaxApplet):
         self.do_initialize.connect(self.initialize_channels)
 
         self.initialize_gui()
+        self.load_config_file("dds", args)
         # connects to LabRAD in a different thread, and calls self.labrad_connected when finished.
         self.connect_to_labrad(args.ip)
 
@@ -62,6 +63,16 @@ class DDS(QtWidgets.QWidget, JaxApplet):
 
             self.list_widget.add_item_and_widget(channel, channel_widget)
 
+        if "list_widget" not in self.config:
+            self.config["list_widget"] = {}
+        self.list_widget_reordered(self.list_widget.set_visibility_and_order(
+            self.config["list_widget"]))
+        self.list_widget.visibility_and_order_changed.connect(self.list_widget_reordered)
+
+    def list_widget_reordered(self, widget_config):
+        self.config["list_widget"] = widget_config
+        self.save_config_file()
+
     async def setup_cxn_listeners(self):
         self.cxn.add_on_connect("artiq", self.run_in_labrad_loop(self.artiq_connected))
         self.cxn.add_on_disconnect("artiq", self.artiq_disconnected)
@@ -84,6 +95,7 @@ class DDS(QtWidgets.QWidget, JaxApplet):
 def main():
     applet = SimpleApplet(DDS)
     DDS.add_labrad_ip_argument(applet)  # adds IP address as an argument.
+    DDS.add_id_argument(applet)
     applet.run()
 
 


### PR DESCRIPTION
Closes #29 and closes #30.

List of changes:
 - `JaxApplet`: Applets can use config files in `__user_folder__/.jax/applets`.
 - `JaxApplet`: `--id` command line arguments that allows the same applet using different config files.
 - `CustomListWidget`: Uses the config to remember the last state.
 - `DDS` applet: Eemembers DDS channel visibility and order across applet restarts.