### PR TITLE
DDS applet waits for finish of the initialization experiment before populating GUI

### DIFF
--- a/tools/applets/dds.py
+++ b/tools/applets/dds.py
@@ -37,18 +37,27 @@ class DDS(QtWidgets.QWidget, JaxApplet):
 
     async def artiq_connected(self):
         self.artiq = self.cxn.get_server("artiq")
+        initialize_now = await self.artiq.is_dds_initialized()
+        if initialize_now:
+            await self.get_dds_parameters()
+
+        SIGNALID = 124890
+        await self.artiq.on_dds_change(SIGNALID)
+        self.artiq.addListener(listener=self._dds_changed, source=None, ID=SIGNALID)
+        await self.artiq.on_dds_initialize(SIGNALID + 1)
+        self.artiq.addListener(listener=self._dds_initialized, source=None, ID=SIGNALID+1)
+
+    async def get_dds_parameters(self):
         self.params = await self.artiq.get_dds_parameters()
         self.params = pyon.decode(self.params)
-        self.do_initialize.emit()  # tells the main thread that it can populate the DDS channels.
-
-        DDS_CHANGE = 124890
-        await self.artiq.on_dds_change(DDS_CHANGE)
-        self.artiq.addListener(listener=self._dds_changed, source=None, ID=DDS_CHANGE)
+        # tells the main thread that it can populate the DDS channels.
+        self.do_initialize.emit()
         self.setDisabled(False)
 
     @QtCore.pyqtSlot()
     def initialize_channels(self):
         self.channels = {}
+        self.list_widget.clear()
         for channel in self.params:
             cpld = "Not implemented"  # current code does not query the cpld name.
             frequency = self.params[channel][0]
@@ -90,6 +99,9 @@ class DDS(QtWidgets.QWidget, JaxApplet):
             self.channels[channel].on_monitor_att_changed(val)
         elif attribute == "state":
             self.channels[channel].on_monitor_switch_changed(val > 0.)
+
+    def _dds_initialized(self, signal, value):
+        self.run_in_labrad_loop(self.get_dds_parameters)(self, text)
 
 
 def main():

--- a/tools/applets/dds.py
+++ b/tools/applets/dds.py
@@ -101,7 +101,7 @@ class DDS(QtWidgets.QWidget, JaxApplet):
             self.channels[channel].on_monitor_switch_changed(val > 0.)
 
     def _dds_initialized(self, signal, value):
-        self.run_in_labrad_loop(self.get_dds_parameters)(self, text)
+        self.run_in_labrad_loop(self.get_dds_parameters)()
 
 
 def main():

--- a/util/ui/custom_list_widget.py
+++ b/util/ui/custom_list_widget.py
@@ -140,6 +140,13 @@ class CustomListWidget(QtWidgets.QListWidget):
             self.update_ui()
             self.visibility_and_order_changed.emit(self._get_config())
 
+    def clear(self):
+        """Overloads the parent clear function to properly clear the extra attributes."""
+        self.visible_items = []
+        self.hidden_items = []
+        self.all_items = {}
+        super().clear()
+
     def addItem(self, item):
         """Do not call this directly. Use self.add_item_and_widget() instead."""
         if not isinstance(item, _CustomListWidgetItem):


### PR DESCRIPTION
See https://github.com/Jayich-Lab/pydux/pull/1801. This prevents a few bugs with the DDS applet when the initialization did not run or failed.

Also correctly implements the `clear` method of `CustomListWidget` to avoid a bug preventing adding a new item after calling the `clear` method.