### PR TITLE
fix applet hang in case of an exception

### DIFF
--- a/base/applets/jax_applet.py
+++ b/base/applets/jax_applet.py
@@ -93,7 +93,7 @@ class JaxApplet(QtCore.QObject):
             self._labrad_loop.create_task(self.labrad_worker(ip))
             self._labrad_loop.run_forever()
 
-        self._labrad_thread = threading.Thread(target=worker)
+        self._labrad_thread = threading.Thread(target=worker, daemon=True)
         self._labrad_thread.start()
 
     def data_changed(self, data, mods):


### PR DESCRIPTION
Closes #36. The applet should no longer hang for minutes in the command line when an exception occurs in the code.