### PR TITLE
dashboard and applet changes

### DIFF
--- a/base/environments/jax_environment.py
+++ b/base/environments/jax_environment.py
@@ -1,10 +1,10 @@
-import threading
 import pickle
+import threading
+
 import numpy as _np
 from artiq.experiment import *
-from jax.util.parameter_group import ParameterGroup
 from jax.util.drift_tracker import DriftTracker
-
+from jax.util.parameter_group import ParameterGroup
 
 __all__ = ["JaxEnvironment"]
 
@@ -33,6 +33,7 @@ class JaxEnvironment(HasEnvironment):
 
     def _connect_labrad(self):
         import labrad
+
         self.cxn = labrad.connect()
         try:
             self.dv = self.cxn.vault
@@ -161,8 +162,9 @@ class JaxEnvironment(HasEnvironment):
         return self.dv.add_dataset(name, value, group_path, shared)
 
     @rpc
-    def add_streaming_dataset(self, name, value, maxshape, rows_stream=1, group_path="/datasets",
-                              shared=False) -> TStr:
+    def add_streaming_dataset(
+        self, name, value, maxshape, rows_stream=1, group_path="/datasets", shared=False
+    ) -> TStr:
         """Adds a streaming dataset that is automatically saved into the file.
 
         Args:
@@ -178,8 +180,9 @@ class JaxEnvironment(HasEnvironment):
         """
         if not self._is_dataset_open:
             self.open_file()
-        return self.dv.add_streaming_dataset(name, value, maxshape, rows_stream,
-                                             group_path, shared)
+        return self.dv.add_streaming_dataset(
+            name, value, maxshape, rows_stream, group_path, shared
+        )
 
     @rpc(flags={"async"})
     def set_dataset(self, dataset_path, value):
@@ -284,8 +287,9 @@ class JaxEnvironment(HasEnvironment):
         Also saves all parameters to the data file.
         """
         from jax.util.labrad import remove_labrad_units
+
         pb = self.cxn.parameter_bank
-        params_serialized, params_full_serialized = pb.get_frozen_parameters(self.scheduler.rid)
+        params_serialized, params_full_serialized = pb.get_cached_parameters(self.scheduler.rid)
         params = pickle.loads(params_serialized)
         params_full = pickle.loads(params_full_serialized)
         for collection, name in self.parameter_paths:

--- a/base/environments/jax_environment.py
+++ b/base/environments/jax_environment.py
@@ -284,12 +284,21 @@ class JaxEnvironment(HasEnvironment):
     def save_parameters(self):
         """Loads all parameters into self.p.
 
+        The function first tries to load cached parameters from the parameter bank. The cached
+        parameters are either preloaded or overridden when the experiment is scheduled.
+        Then it loads parameters not saved as cached parameters in the experiment.
+
         Also saves all parameters to the data file.
+        The experiment parameter values are saved under the "parameters" key of the data file.
+        The full form of the experiment parameters (including the parameter type, range, etc.)
+        are saved under the "parameter_full" key of the data file.
         """
         from jax.util.labrad import remove_labrad_units
 
         pb = self.cxn.parameter_bank
-        params_serialized, params_full_serialized = pb.get_cached_parameters(self.scheduler.rid)
+        params_serialized, params_full_serialized = pb.get_cached_parameters(
+            self.scheduler.rid
+        )
         params = pickle.loads(params_serialized)
         params_full = pickle.loads(params_full_serialized)
         for collection, name in self.parameter_paths:

--- a/base/environments/jax_environment.py
+++ b/base/environments/jax_environment.py
@@ -300,7 +300,7 @@ class JaxEnvironment(HasEnvironment):
             if name not in params_full[collection]:
                 value_full = pb.get_raw_form(collection, name)
             else:
-                value = params_full[collection][name]
+                value_full = params_full[collection][name]
             params_full[collection][name] = remove_labrad_units(value_full)
         self.p = ParameterGroup(params)
         self.add_attribute("parameters", self.serialize(params))

--- a/tools/applets/dds_channel.py
+++ b/tools/applets/dds_channel.py
@@ -1,9 +1,10 @@
-from PyQt5 import QtWidgets, QtGui, QtCore
 from jax.util.ui.dialog_on_top import DialogOnTop
+from PyQt5 import QtCore, QtGui, QtWidgets
 
 
 class DDSParameters:
     """Stores DDS parameters and calls the artiq server when changes are made."""
+
     def __init__(self, parent, channel, cpld, amplitude, att, frequency, phase, state):
         self.parent = parent
         self.channel = channel
@@ -61,9 +62,9 @@ class DDSParameters:
     def set_state(self, value, update=True):
         if value != self._state and update:
             if value:
-                value_set = 1.
+                value_set = 1.0
             else:
-                value_set = -1.
+                value_set = -1.0
             command = (self.channel, "state", value_set)
             self._change_dds(command)
         self._state = value
@@ -77,6 +78,7 @@ class DDSParameters:
 
 class DDSDetail(DialogOnTop):
     """A dialog showing details for a channel."""
+
     def __init__(self, dds_parameters, parent=None):
         self.dds_parameters = dds_parameters
         super().__init__(parent)
@@ -87,25 +89,23 @@ class DDSDetail(DialogOnTop):
     def initialize_gui(self):
         grid = QtWidgets.QGridLayout()
         self.setLayout(grid)
-        labelfont = QtGui.QFont('Arial', 10)
-        spinboxfont = QtGui.QFont('Arial', 15)
+        labelfont = QtGui.QFont("Arial", 7)
+        spinboxfont = QtGui.QFont("Arial", 10)
 
         label = QtWidgets.QLabel(f"CPLD: {self.dds_parameters.cpld}")
-        label.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
-                            QtWidgets.QSizePolicy.Fixed)
+        label.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
         label.setFont(labelfont)
         grid.addWidget(label, 0, 0)
 
         label = QtWidgets.QLabel("Att (dB)")
-        label.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
-                            QtWidgets.QSizePolicy.Fixed)
+        label.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
         label.setFont(labelfont)
         grid.addWidget(label, 1, 0)
 
         self.att_box = QtWidgets.QDoubleSpinBox()
         self.att_box.setDecimals(1)
         self.att_box.setMinimum(-31.5)
-        self.att_box.setMaximum(0.)
+        self.att_box.setMaximum(0.0)
         self.att_box.setSingleStep(0.5)
         self.att_box.setFont(spinboxfont)
         self.att_box.setKeyboardTracking(False)
@@ -121,6 +121,7 @@ class DDSDetail(DialogOnTop):
 
 class DDSChannel(QtWidgets.QGroupBox):
     """GUI for a DDS channel."""
+
     def __init__(self, dds_parameters, parent=None):
         self.dds_parameters = dds_parameters
         super().__init__(parent)
@@ -128,32 +129,30 @@ class DDSChannel(QtWidgets.QGroupBox):
         self.setup_gui_listeners()
 
     def initialize_gui(self):
-        titlefont = QtGui.QFont('Arial', 16)
-        labelfont = QtGui.QFont('Arial', 10)
-        buttonfont = QtGui.QFont('Arial', 15)
-        spinboxfont = QtGui.QFont('Arial', 15)
+        titlefont = QtGui.QFont("Arial", 10)
+        labelfont = QtGui.QFont("Arial", 7)
+        buttonfont = QtGui.QFont("Arial", 10)
+        spinboxfont = QtGui.QFont("Arial", 10)
 
         grid = QtWidgets.QGridLayout()
         self.setLayout(grid)
-        self.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
-                           QtWidgets.QSizePolicy.Fixed)
+        self.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
 
         label = QtWidgets.QLabel(self.dds_parameters.channel)
-        label.setSizePolicy(QtWidgets.QSizePolicy.Expanding,
-                            QtWidgets.QSizePolicy.Fixed)
+        label.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+        )
         label.setAlignment(QtCore.Qt.AlignHCenter)
         label.setFont(titlefont)
         grid.addWidget(label, 0, 0, 1, 3)
 
         label = QtWidgets.QLabel("Frequency (MHz)")
-        label.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
-                            QtWidgets.QSizePolicy.Fixed)
+        label.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
         label.setFont(labelfont)
         grid.addWidget(label, 1, 0)
 
         label = QtWidgets.QLabel("Amplitude")
-        label.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
-                            QtWidgets.QSizePolicy.Fixed)
+        label.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
         label.setFont(labelfont)
         grid.addWidget(label, 1, 1)
 
@@ -164,7 +163,7 @@ class DDSChannel(QtWidgets.QGroupBox):
         self.freq_box.setSingleStep(0.1)
         self.freq_box.setFont(spinboxfont)
         self.freq_box.setKeyboardTracking(False)
-        MHz_to_Hz = 1.e6
+        MHz_to_Hz = 1.0e6
         self.freq_box.setValue(self.dds_parameters.frequency / MHz_to_Hz)
         grid.addWidget(self.freq_box, 2, 0)
 
@@ -174,16 +173,18 @@ class DDSChannel(QtWidgets.QGroupBox):
         self.amp_box.setMaximum(1.0)
         self.amp_box.setSingleStep(0.01)
         self.amp_box.setFont(spinboxfont)
-        self.amp_box.setSizePolicy(QtWidgets.QSizePolicy.Preferred,
-                                   QtWidgets.QSizePolicy.Preferred)
+        self.amp_box.setSizePolicy(
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Preferred
+        )
         self.amp_box.setKeyboardTracking(False)
         self.amp_box.setValue(self.dds_parameters.amplitude)
         grid.addWidget(self.amp_box, 2, 1)
 
         self.switch_button = QtWidgets.QPushButton("o")
         self.switch_button.setFont(buttonfont)
-        self.switch_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
-                                         QtWidgets.QSizePolicy.Fixed)
+        self.switch_button.setSizePolicy(
+            QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
+        )
         self.switch_button.setCheckable(True)
         if self.dds_parameters.state:
             self.switch_button.setChecked(self.dds_parameters.state)
@@ -196,7 +197,7 @@ class DDSChannel(QtWidgets.QGroupBox):
         self.switch_button.clicked.connect(self.on_widget_switch_changed)
 
     def on_widget_freq_changed(self, val):
-        MHz_to_Hz = 1.e6
+        MHz_to_Hz = 1.0e6
         self.dds_parameters.set_frequency(val * MHz_to_Hz)
 
     def on_widget_amp_changed(self, val):
@@ -207,7 +208,7 @@ class DDSChannel(QtWidgets.QGroupBox):
         self.set_switch_button_text(checked)
 
     def on_monitor_freq_changed(self, val):
-        MHz_to_Hz = 1.e6
+        MHz_to_Hz = 1.0e6
         self.freq_box.blockSignals(True)
         self.freq_box.setValue(val / MHz_to_Hz)
         self.freq_box.blockSignals(False)

--- a/tools/applets/dds_channel.py
+++ b/tools/applets/dds_channel.py
@@ -89,7 +89,7 @@ class DDSDetail(DialogOnTop):
     def initialize_gui(self):
         grid = QtWidgets.QGridLayout()
         self.setLayout(grid)
-        labelfont = QtGui.QFont("Arial", 7)
+        labelfont = QtGui.QFont("Arial", 8)
         spinboxfont = QtGui.QFont("Arial", 10)
 
         label = QtWidgets.QLabel(f"CPLD: {self.dds_parameters.cpld}")
@@ -130,7 +130,7 @@ class DDSChannel(QtWidgets.QGroupBox):
 
     def initialize_gui(self):
         titlefont = QtGui.QFont("Arial", 10)
-        labelfont = QtGui.QFont("Arial", 7)
+        labelfont = QtGui.QFont("Arial", 8)
         buttonfont = QtGui.QFont("Arial", 10)
         spinboxfont = QtGui.QFont("Arial", 10)
 

--- a/tools/applets/explorer.py
+++ b/tools/applets/explorer.py
@@ -41,11 +41,11 @@ class Explorer(QtWidgets.QWidget, JaxApplet):
 
         self._disconnected_reported = False
         asyncio.get_event_loop().run_until_complete(
-            self.connect_subscribers()
+            self.connect_subscribers()  # run in the main thread asyncio loop.
         )
 
         self.initialize_gui()
-        self.connect_to_labrad(args.ip)
+        self.connect_to_labrad("::1")  # only works on localhost.
 
     async def connect_subscribers(self):
         localhost = "::1"
@@ -203,7 +203,6 @@ class Explorer(QtWidgets.QWidget, JaxApplet):
 def main():
     QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
     applet = SimpleApplet(Explorer)
-    Explorer.add_labrad_ip_argument(applet)
     applet.run()
 
 

--- a/tools/applets/explorer.py
+++ b/tools/applets/explorer.py
@@ -11,6 +11,7 @@ from artiq.gui.models import ModelSubscriber
 from artiq.master.worker_impl import ExamineDeviceMgr, ExamineDatasetMgr, TraceArgumentManager
 
 from jax import JaxApplet
+from jax.util.ui.dialog_on_top import DialogOnTop
 
 
 class StatusUpdater:
@@ -33,21 +34,151 @@ class StatusUpdater:
                 self.explorer.update_scanning(v)
 
 
+class ExperimentDetails(DialogOnTop):
+    """A dialog showing details of an experiment."""
+    def __init__(self, expurl, parent):
+        super().__init__(parent)
+        self.expurl = expurl
+        self._expinfo = self.parent()._resolve_expurl(expurl)
+        self.setWindowTitle(self._expinfo["class_name"])
+        self.initialize_gui()
+
+    def initialize_gui(self):
+        grid = QtWidgets.QGridLayout()
+        self.setLayout(grid)
+
+        label_priority = QtWidgets.QLabel("Priority")
+        label_priority.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
+        grid.addWidget(label_priority, 0, 0)
+
+        self.spinbox_priority = QtWidgets.QSpinBox()
+        self.spinbox_priority.setMinimum(-100)
+        self.spinbox_priority.setMaximum(100)
+        default_priority = self._expinfo["scheduler_defaults"].get("priority", 0)
+        self.spinbox_priority.setValue(default_priority)
+        grid.addWidget(self.spinbox_priority, 0, 1)
+
+        label_pipeline = QtWidgets.QLabel("Pipeline")
+        label_pipeline.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
+        grid.addWidget(label_pipeline, 1, 0)
+    
+        self.textbox_pipeline = QtWidgets.QLineEdit()
+        default_pipeline = self._expinfo["scheduler_defaults"].get("pipeline_name", "main")
+        self.textbox_pipeline.setText(default_pipeline)
+        grid.addWidget(self.textbox_pipeline, 1, 1)
+
+        label_log_level = QtWidgets.QLabel("Log level")
+        label_log_level.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
+        grid.addWidget(label_log_level, 2, 0)
+
+        self.combobox_log_level = QtWidgets.QComboBox()
+        self.combobox_log_level.addItems(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
+        self.combobox_log_level.setCurrentIndex(1)
+        grid.addWidget(self.combobox_log_level, 2, 1)
+
+        self.checkbox_preload = QtWidgets.QCheckBox("Preload parameters when scheduled")
+        self.checkbox_preload.setChecked(True)
+        self.checkbox_preload.setToolTip("Uses the parameters when the experiment is scheduled.")
+        grid.addWidget(self.checkbox_preload, 3, 0, 1, 2)
+
+        submit = QtWidgets.QPushButton("Submit")
+        submit.setIcon(
+            QtWidgets.QApplication.style().standardIcon(QtWidgets.QStyle.SP_DialogOkButton)
+        )
+        submit.clicked.connect(self.submit_clicked)
+        submit.setToolTip("Schedule the selected experiment")
+        grid.addWidget(submit, 4, 0, 1, 2)
+
+    def submit_clicked(self):
+        self.parent().submit(
+            self.checkbox_preload.isChecked(),
+            self.spinbox_priority.value(),
+            self.textbox_pipeline.text(),
+            getattr(logging, self.combobox_log_level.currentText()),
+            self.expurl
+        )
+        self.close()
+
+
 class Explorer(QtWidgets.QWidget, JaxApplet):
-    """TODO: priority, pipeline_name, log_level, docstrings."""
+    """Experiment explorer.
+
+    Modified from artiq.dashboard.explorer.ExplorerDock.
+    It supports running the experiment with parameter preloaded when the experiment
+    is scheduled. It can be connected with the parameter bank GUI to show only
+    relevant parameters for the experiment chosen.
+    This applet needs to be restarted when the ARTIQ master restarts.
+    """
+    # subscribe to this method to update when an experiment is selected / deselected.
+    # TODO: add a blank experiment to show all parameters.
+    parameters_updated = QtCore.pyqtSignal(object)
+
     def __init__(self, args, **kwds):
         super().__init__(**kwds)
         self.setDisabled(True)
+        self.initialize_gui()
 
-        self._disconnected_reported = False
+        self._disconnect_reported = False
         asyncio.get_event_loop().run_until_complete(
             self.connect_subscribers()  # run in the main thread asyncio loop.
         )
 
-        self.initialize_gui()
-        self.connect_to_labrad("::1")  # only works on localhost.
+        self.connect_to_labrad("::1")
+
+    def initialize_gui(self):
+        layout = QtWidgets.QGridLayout()
+
+        self.stack = QtWidgets.QStackedWidget()  # either shows the explorer or the waiting panel.
+        layout.addWidget(self.stack, 0, 0)
+
+        self.explorer = QtWidgets.QTreeView()
+        self.explorer.setHeaderHidden(True)
+        self.explorer.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectItems)
+        self.stack.addWidget(self.explorer)
+
+        submit = QtWidgets.QPushButton("Submit")
+        submit.setIcon(
+            QtWidgets.QApplication.style().standardIcon(QtWidgets.QStyle.SP_DialogOkButton)
+        )
+        submit.setToolTip("Schedule the selected experiment")
+        layout.addWidget(submit, 1, 0)
+        submit.clicked.connect(self.submit)
+
+        self._create_context_menu()
+
+        self.waiting_panel = explorer.WaitingPanel()
+        self.stack.addWidget(self.waiting_panel)
+
+        self.repo_path = None
+        self._parameters_initialized = True
+        self._experiment_parameters = {}
+        self.setLayout(layout)
+
+    def _create_context_menu(self):
+        self.explorer.setContextMenuPolicy(QtCore.Qt.ActionsContextMenu)
+
+        submit_action = QtWidgets.QAction("Submit", self.explorer)
+        submit_action.triggered.connect(self.submit)
+        self.explorer.addAction(submit_action)
+
+        detail_action = QtWidgets.QAction("Details", self.explorer)
+        detail_action.triggered.connect(self.show_details)
+        self.explorer.addAction(detail_action)
+
+        scan_repository_action = QtWidgets.QAction("Scan repository", self.explorer)
+        scan_repository_action.triggered.connect(self.scan_repository)
+        self.explorer.addAction(scan_repository_action)
+
+        scan_devices_action = QtWidgets.QAction("Scan devices", self.explorer)
+        scan_devices_action.triggered.connect(self.scan_devices)
+        self.explorer.addAction(scan_devices_action)
 
     async def connect_subscribers(self):
+        """Connect subscribers to ARTIQ notification publishers.
+
+        The subscribers and publishers are similar to LabRAD signals. We need to get
+        updates of the experiment management using them. They only work on localhost.
+        """
         localhost = "::1"
         port_notify = 3250
         self._explist_sub = ModelSubscriber("explist", explorer.Model, self._report_disconnect)
@@ -57,44 +188,27 @@ class Explorer(QtWidgets.QWidget, JaxApplet):
         )
         await self._explist_status_sub.connect(localhost, port_notify)
 
-    def initialize_gui(self):
-        font = QtGui.QFont()
-        layout = QtWidgets.QGridLayout()
-        self.stack = QtWidgets.QStackedWidget()
-        layout.addWidget(self.stack, 0, 0)
-        self.explorer = QtWidgets.QTreeView()
-        self.explorer.setHeaderHidden(True)
-        self.explorer.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectItems)
-        self.explorer.setFont(font)
-        self.stack.addWidget(self.explorer)
-
-        submit = QtWidgets.QPushButton("Submit")
-        submit.setIcon(
-            QtWidgets.QApplication.style().standardIcon(QtWidgets.QStyle.SP_DialogOkButton)
-        )
-        submit.setFont(font)
-        submit.setToolTip("Schedule the selected experiment")
-        layout.addWidget(submit, 1, 0)
-        submit.clicked.connect(self.submit)
-
         self.explist_model = explorer.Model(dict())
+        self.explorer.setModel(self.explist_model)
+        self.explorer.selectionModel().selectionChanged.connect(self.selection_changed)
         self._explist_sub.add_setmodel_callback(self.set_model)
-
-        self.explorer.setContextMenuPolicy(QtCore.Qt.ActionsContextMenu)
-        scan_repository_action = QtWidgets.QAction("Scan repository", self.explorer)
-        scan_repository_action.triggered.connect(self.scan_repository)
-        self.explorer.addAction(scan_repository_action)
-
-        scan_devices_action = QtWidgets.QAction("Scan devices", self.explorer)
-        scan_devices_action.triggered.connect(self.scan_devices)
-        self.explorer.addAction(scan_devices_action)
-
-        self.waiting_panel = explorer.WaitingPanel()
-        self.stack.addWidget(self.waiting_panel)
         self._explist_status_sub.add_setmodel_callback(
-            lambda updater: updater.set_explorer(self))
+            lambda updater: updater.set_explorer(self)
+        )
 
-        self.setLayout(layout)
+    def _report_disconnect(self):
+        """Handles subscriber disconnections.
+
+        Currently the applet must be restarted after a subscriber disconnection which
+        is typically due to ARTIQ master stopping. We can reconnect when the ARTIQ server
+        restarts, or when the ARTIQ master is restarted using the ARTIQ server is restarted.
+        It is not implemented now due to the complexity with communication between LabRAD
+        and ARTIQ event loops. This can be implemented easier with rockdove.
+        """
+        if not self._disconnect_reported:
+            logging.error("connection to master lost, restart dashboard to reconnect")
+            self.setDisabled(True)
+        self._disconnect_reported = True
 
     async def labrad_connected(self):
         await self.artiq_connected()
@@ -106,20 +220,21 @@ class Explorer(QtWidgets.QWidget, JaxApplet):
 
     async def artiq_connected(self):
         self.artiq = self.cxn.get_server("artiq")
-        self.repo_path = await self.artiq.get_repository_path()
         device_db = await self.artiq.get_device_db()
         self.device_db = pickle.loads(device_db)
+        # patch the `ExamineDeviceMgr.get_device_db` method.
         ExamineDeviceMgr.get_device_db = lambda: self.device_db
-        self.setDisabled(False)
+        self.repo_path = await self.artiq.get_repository_path()
+
+        if not self._parameters_initialized:
+            self._get_all_experiment_parameters()
+            self._parameters_initialized = True
+
+        if not self._disconnect_reported:
+            self.setDisabled(False)
 
     def artiq_disconnected(self):
         self.setDisabled(True)
-
-    def _report_disconnect(self):
-        if not self._disconnected_reported:
-            logging.error("connection to master lost, restart dashboard to reconnect")
-            self.setDisabled(True)
-        self._disconnect_reported = True
 
     def scan_repository(self):
         async def worker():
@@ -137,10 +252,11 @@ class Explorer(QtWidgets.QWidget, JaxApplet):
         self.run_in_labrad_loop(worker)()
 
     def set_model(self, model):
+        """Called when the experiment list subscriber receives an update."""
         self.explist_model = model
         self.explorer.setModel(model)
 
-    def _get_selected_expname(self):
+    def _get_selected_expurl(self):
         selection = self.explorer.selectedIndexes()
         if selection:
             return self.explist_model.index_to_key(selection[0])
@@ -151,17 +267,38 @@ class Explorer(QtWidgets.QWidget, JaxApplet):
         expinfo = self.explist_model.backing_store[expurl]
         return expinfo
 
-    async def _submit_experiment(self, expurl):
+    def show_details(self):
+        expurl = self._get_selected_expurl()
+        details = ExperimentDetails(expurl, self)
+        details.exec_()
+
+    async def _submit_experiment(
+        self,
+        expurl,
+        preload_parameters=True,
+        priority=None,
+        pipeline=None,
+        log_level=None
+    ):
         expinfo = self._resolve_expurl(expurl)
         file = expinfo["file"]
         class_name = expinfo["class_name"]
-        priority = expinfo["scheduler_defaults"].get("priority", 0)
-        pipeline = expinfo["scheduler_defaults"].get("pipeline_name", "main")
-        required_params = self._get_experiment_parameters(
-            os.path.join(self.repo_path, file), class_name
-        )
-        parameter_override_list = []
-        log_level = 20
+        if priority is None:
+            priority = expinfo["scheduler_defaults"].get("priority", 0)
+        if pipeline is None:
+            pipeline = expinfo["scheduler_defaults"].get("pipeline_name", "main")
+        if log_level is None:
+            log_level = 20
+
+        if preload_parameters:
+            # If the experiment is changed after last repository scan, the parameters
+            # may have been changed and the cache saved in `self._experiment_parameters`
+            # should not be used.
+            required_params = self._get_experiment_parameters(file, class_name)
+        else:
+            required_params = []
+        parameter_override_list = []  # TODO: implement parameter scanning / overriding.
+        
         await self.artiq.schedule_experiment_with_parameters(
             file,
             class_name,
@@ -172,22 +309,78 @@ class Explorer(QtWidgets.QWidget, JaxApplet):
             log_level,
         )
 
-    def submit(self):
-        expname = self._get_selected_expname()
-        if expname is not None:
-            self.run_in_labrad_loop(self._submit_experiment)(expname)
+    def submit(
+        self,
+        preload_parameters=True,
+        priority=None,
+        pipeline=None,
+        log_level=None,
+        expurl=None
+    ):
+        if expurl is None:
+            expurl = self._get_selected_expurl()
+        if expurl is not None:
+            self.run_in_labrad_loop(self._submit_experiment)(
+                expurl=expurl,
+                preload_parameters=preload_parameters,
+                priority=priority,
+                pipeline=pipeline,
+                log_level=log_level
+            )
 
     def update_scanning(self, scanning):
+        """When the experiment list status subscriber is updated.
+
+        After a scanning, updates the experiment parameters cache and triggers
+        the parameters_updated signal.
+        """
         if scanning:
             self.stack.setCurrentWidget(self.waiting_panel)
             self.waiting_panel.start()
         else:
+            if self.repo_path is not None:
+                self._get_all_experiment_parameters()
+            else:
+                self._parameters_initialized = False
             self.stack.setCurrentWidget(self.explorer)
+            self.selection_changed(None, None)
             self.waiting_panel.stop()
 
+    def selection_changed(self, selected, deselected):
+        """Triggers the parameter_updated signal."""
+        expurl = self._get_selected_expurl()
+        if expurl is None and expurl in self._experiment_parameters:
+            self.parameters_updated.emit(self._experiment_parameters[expurl])
+        else:
+            self.parameters_updated.emit([])
+
+    def _get_all_experiment_parameters(self):
+        self._experiment_parameters = {}
+        for expurl in self.explist_model.backing_store:
+            expinfo = self._resolve_expurl(expurl)
+            file = expinfo["file"]
+            class_name = expinfo["class_name"]
+            self._experiment_parameters[expurl] = self._get_experiment_parameters(
+                file, class_name
+            )
+
     def _get_experiment_parameters(self, file, class_name):
+        """Creates the experiment class and tries to get the required parameters of the experiment.
+
+        It imports the experiment module, builds the class, and tries to read the `parameter_paths`
+        attribute of the experiment.
+
+        Args:
+            file: str, file path from the repository root.
+            class_name: str, name of the experiment class.
+
+        Returns:
+            list of 2-tuples of strs, list of required parameters in
+            (collection_name, parameter_name). If the experiment does not have required parmeters,
+            it returns an empty list.
+        """
         module_name = os.path.basename(file).split(".")[0]
-        file = os.path.join("C:\\Users\\scientist\\code\\spock", file)
+        file = os.path.join(self.repo_path, file)
         spec = importlib.util.spec_from_file_location(module_name, file)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
@@ -198,6 +391,22 @@ class Explorer(QtWidgets.QWidget, JaxApplet):
         except AttributeError as e:
             parameter_paths = []  # allows experiments without parameter_paths to run.
         return parameter_paths
+
+    def closeEvent(self, a0: QtGui.QCloseEvent) -> None:
+        """Closes subscribers when the applet is closed."""
+        async def close_subscribers():
+            try:
+                await self._explist_sub.close()
+            except Exception as e:
+                pass
+            try:
+                await self._explist_status_sub.close()
+            except Exception as e:
+                pass
+        asyncio.run_coroutine_threadsafe(
+            close_subscribers(), asyncio.get_event_loop()
+        )
+        return super().closeEvent(a0)
 
 
 def main():

--- a/tools/applets/explorer.py
+++ b/tools/applets/explorer.py
@@ -1,0 +1,175 @@
+import asyncio
+import importlib.util
+import logging
+import os
+import pickle
+from functools import partial
+
+from PyQt5 import QtGui, QtWidgets, QtCore
+from artiq.applets.simple import SimpleApplet
+from artiq.dashboard import explorer
+from artiq.gui.models import ModelSubscriber
+from artiq.master.worker_impl import ExamineDeviceMgr, ExamineDatasetMgr, TraceArgumentManager
+
+from jax import JaxApplet
+
+
+class Explorer(QtWidgets.QWidget, JaxApplet):
+    def __init__(self, args, **kwds):
+        super().__init__(**kwds)
+        self.setDisabled(True)
+
+        self._disconnected_reported = False
+        self._explist_sub = ModelSubscriber("explist", explorer.Model)
+        self._explist_status_sub = ModelSubscriber("explist_status", explorer.StatusUpdater)
+
+        self.initialize_gui()
+        self.connect_to_labrad(args.ip)
+        asyncio.run_coroutine_threadsafe(
+            self.start_subscribers(),
+            asyncio.get_event_loop()
+        )
+
+    async def start_subscribers(self):
+        port_notify = 3250
+        await self._explist_sub.connect("::1", port_notify)
+        await self._explist_status_sub.connect("::1", port_notify)
+
+    def initialize_gui(self):
+        layout = QtWidgets.QGridLayout()
+        self.stack = QtWidgets.QStackedWidget()
+        layout.addWidget(self.stack, 0, 0)
+        self.explorer = QtWidgets.QTreeView()
+        self.explorer.setHeaderHidden(True)
+        self.explorer.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectItems)
+        self.stack.addWidget(self.explorer)
+
+        submit = QtWidgets.QPushButton("Submit")
+        submit.setIcon(
+            QtWidgets.QApplication.style().standardIcon(QtWidgets.QStyle.SP_DialogOkButton)
+        )
+        submit.setToolTip("Schedule the selected experiment")
+        layout.addWidget(submit, 1, 0)
+        submit.clicked.connect(partial(self.expname_action, "submit"))
+
+        self.explist_model = explorer.Model(dict())
+        self._explist_sub.add_setmodel_callback(self.set_model)
+
+        self.explorer.setContextMenuPolicy(QtCore.Qt.ActionsContextMenu)
+        scan_repository_action = QtWidgets.QAction("Scan repository", self.explorer)
+        scan_repository_action.triggered.connect(self.scan_repository)
+        self.explorer.addAction(scan_repository_action)
+
+        scan_devices_action = QtWidgets.QAction("Scan devices", self.explorer)
+        scan_devices_action.triggered.connect(self.scan_devices)
+        self.explorer.addAction(scan_devices_action)
+
+        self.waiting_panel = explorer.WaitingPanel()
+        self.stack.addWidget(self.waiting_panel)
+        self._explist_status_sub.add_setmodel_callback(
+            lambda updater: updater.set_explorer(self))
+
+        self.setLayout(layout)
+
+    async def labrad_connected(self):
+        await self.artiq_connected()
+        await self.setup_cxn_listeners()
+
+    async def setup_cxn_listeners(self):
+        self.cxn.add_on_connect("artiq", self.run_in_labrad_loop(self.artiq_connected))
+        self.cxn.add_on_disconnect("artiq", self.artiq_disconnected)
+
+    async def artiq_connected(self):
+        self.artiq = self.cxn.get_server("artiq")
+        device_db = await self.artiq.get_device_db()
+        self.device_db = pickle.loads(device_db)
+        ExamineDeviceMgr.get_device_db = lambda: self.device_db
+        self.setDisabled(False)
+
+    def artiq_disconnected(self):
+        self.setDisabled(True)
+
+    def _report_disconnect(self):
+        if not self._disconnected_reported:
+            logging.error("connection to master lost, restart dashboard to reconnect")
+            self.setDisabled(True)
+        self._disconnect_reported = True
+
+    def scan_repository(self):
+        async def worker():
+            await self.artiq.scan_experiment_repository(False)
+
+        self.run_in_labrad_loop(worker)()
+
+    def scan_devices(self):
+        async def worker():
+            await self.artiq.scan_device_db()
+            device_db = await self.artiq.get_device_db()
+            self.device_db = pickle.loads(device_db)
+
+        self.run_in_labrad_loop(worker)()
+
+    def set_model(self, model):
+        self.explist_model = model
+        self.explorer.setModel(model)
+
+    def _get_selected_expname(self):
+        selection = self.explorer.selectedIndexes()
+        if selection:
+            return self.explist_model.index_to_key(selection[0])
+        else:
+            return None
+
+    def _resolve_expurl(self, expurl):
+        expinfo = self.explist_model.backing_store[expurl]
+        return (expinfo["file"], expinfo["class_name"])
+
+    async def _submit_experiment(self, expurl):
+        """TODO: Handle experiment parameters, priority, pipeline, and log_level correctly."""
+        file, class_name = self._resolve_expurl(expurl)
+        await self.artiq.schedule_experiment_with_parameters(file, class_name)
+
+    def expname_action(self, action):
+        expname = self._get_selected_expname()
+        if expname is not None:
+            if action == "submit":
+                self.run_in_labrad_loop(self._submit_experiment)(expname)
+
+    def update_scanning(self, scanning):
+        """TODO: This is not working."""
+        if scanning:
+            self.stack.setCurrentWidget(self.waiting_panel)
+            self.waiting_panel.start()
+        else:
+            self.stack.setCurrentWidget(self.el_buttons)
+            self.waiting_panel.stop()
+
+    def update_cur_rev(self, cur_rev):
+        """This function is not implemented.
+
+        We do not show the current revision of the repository in the GUI
+        as we do not use the git backend of the artiq experiment manager.
+        This function is for compatibility with `artiq.dashboard.explorer.StatusUpdater`.
+        """
+        pass
+
+    def get_experiment_parameters(self, file, class_name):
+        module_name = os.path.basename(file).split(".")[0]
+        spec = importlib.util.spec_from_file_location(module_name, file)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        cls = getattr(module, class_name)
+        exp = cls(ExamineDeviceMgr, ExamineDatasetMgr, TraceArgumentManager(), {})
+        return exp.parameter_paths
+
+
+def main():
+    applet = SimpleApplet(Explorer)
+    Explorer.add_labrad_ip_argument(applet)
+    applet.run()
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/tools/applets/pmt.py
+++ b/tools/applets/pmt.py
@@ -1,6 +1,6 @@
-from PyQt5 import QtWidgets, QtCore, QtGui
 from artiq.applets.simple import SimpleApplet
 from jax import JaxApplet
+from PyQt5 import QtCore, QtGui, QtWidgets
 
 
 class PMT(QtWidgets.QWidget, JaxApplet):
@@ -36,23 +36,26 @@ class PMT(QtWidgets.QWidget, JaxApplet):
         mode_label = QtWidgets.QLabel("Mode:")
         mode_label.setAlignment(QtCore.Qt.AlignBottom)
         mode_label.setFont(QtGui.QFont(shell_font, pointSize=12))
-        mode_label.setSizePolicy(QtWidgets.QSizePolicy.Preferred,
-                                 QtWidgets.QSizePolicy.Maximum)
+        mode_label.setSizePolicy(
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
+        )
         layout.addWidget(mode_label, 1, 0)
 
         self.mode_combobox = QtWidgets.QComboBox()
         self.mode_combobox.addItem(self._normal_mode_text)
         self.mode_combobox.addItem(self._differential_mode_text)
         self.mode_combobox.setFont(QtGui.QFont(shell_font, pointSize=12))
-        self.mode_combobox.setSizePolicy(QtWidgets.QSizePolicy.Preferred,
-                                         QtWidgets.QSizePolicy.Maximum)
+        self.mode_combobox.setSizePolicy(
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
+        )
         layout.addWidget(self.mode_combobox, 2, 0)
 
         interval_label = QtWidgets.QLabel("Interval:")
         interval_label.setAlignment(QtCore.Qt.AlignBottom)
         interval_label.setFont(QtGui.QFont(shell_font, pointSize=12))
-        interval_label.setSizePolicy(QtWidgets.QSizePolicy.Preferred,
-                                     QtWidgets.QSizePolicy.Maximum)
+        interval_label.setSizePolicy(
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
+        )
         layout.addWidget(interval_label, 3, 0)
 
         self.interval_spinbox = QtWidgets.QDoubleSpinBox()
@@ -60,14 +63,16 @@ class PMT(QtWidgets.QWidget, JaxApplet):
         self.interval_spinbox.setSingleStep(0.1)
         self.interval_spinbox.setDecimals(2)
         self.interval_spinbox.setFont(QtGui.QFont(shell_font, pointSize=12))
-        self.interval_spinbox.setSizePolicy(QtWidgets.QSizePolicy.Preferred,
-                                            QtWidgets.QSizePolicy.Maximum)
+        self.interval_spinbox.setSizePolicy(
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
+        )
         layout.addWidget(self.interval_spinbox, 4, 0)
 
         self.start_button = QtWidgets.QPushButton("Start")
         self.start_button.setFont(QtGui.QFont(shell_font, pointSize=12))
-        self.start_button.setSizePolicy(QtWidgets.QSizePolicy.Preferred,
-                                        QtWidgets.QSizePolicy.Maximum)
+        self.start_button.setSizePolicy(
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
+        )
         self.start_button.setCheckable(True)
         layout.addWidget(self.start_button, 5, 0)
         self.setLayout(layout)
@@ -84,7 +89,9 @@ class PMT(QtWidgets.QWidget, JaxApplet):
         await self.dv.subscribe_to_shared_dataset(self._pmt_counts_dataset)
         SHARED_DATA_CHANGE = 128936
         await self.dv.on_shared_data_change(SHARED_DATA_CHANGE)
-        self.dv.addListener(listener=self._data_change, source=None, ID=SHARED_DATA_CHANGE)
+        self.dv.addListener(
+            listener=self._data_change, source=None, ID=SHARED_DATA_CHANGE
+        )
         self.set_disable_state()
 
     async def pmt_connected(self):
@@ -104,16 +111,24 @@ class PMT(QtWidgets.QWidget, JaxApplet):
         self.pmt.addListener(listener=self._new_pmt_mode, source=None, ID=NEW_MODE)
         NEW_INTERVAL = 128938
         await self.pmt.on_new_interval(NEW_INTERVAL)
-        self.pmt.addListener(listener=self._new_pmt_interval, source=None, ID=NEW_INTERVAL)
+        self.pmt.addListener(
+            listener=self._new_pmt_interval, source=None, ID=NEW_INTERVAL
+        )
         FILE_HALF_FULL = 128939
         await self.pmt.on_file_half_full(FILE_HALF_FULL)
-        self.pmt.addListener(listener=self._file_half_full, source=None, ID=FILE_HALF_FULL)
+        self.pmt.addListener(
+            listener=self._file_half_full, source=None, ID=FILE_HALF_FULL
+        )
         AUTO_NEW_FILE = 128940
         await self.pmt.on_auto_new_file(AUTO_NEW_FILE)
-        self.pmt.addListener(listener=self._auto_new_file, source=None, ID=AUTO_NEW_FILE)
+        self.pmt.addListener(
+            listener=self._auto_new_file, source=None, ID=AUTO_NEW_FILE
+        )
         START_STOP = 128941
         await self.pmt.on_start_and_stop(START_STOP)
-        self.pmt.addListener(listener=self._on_start_and_stop, source=None, ID=START_STOP)
+        self.pmt.addListener(
+            listener=self._on_start_and_stop, source=None, ID=START_STOP
+        )
         self.set_disable_state()
 
     async def setup_cxn_listeners(self):

--- a/tools/applets/schedule.py
+++ b/tools/applets/schedule.py
@@ -1,0 +1,166 @@
+import asyncio
+import importlib.util
+import logging
+import os
+import pickle
+from functools import partial
+
+from PyQt5 import QtGui, QtWidgets, QtCore
+from artiq.applets.simple import SimpleApplet
+from artiq.dashboard import schedule
+from artiq.gui.models import ModelSubscriber
+
+from jax import JaxApplet
+
+
+logger = logging.getLogger(__name__)
+
+
+class Schedule(QtWidgets.QWidget, JaxApplet):
+    def __init__(self, args, **kwds):
+        super().__init__(**kwds)
+        self.setDisabled(True)
+
+        asyncio.get_event_loop().run_until_complete(
+            self.connect_subscribers()  # run in the main thread asyncio loop.
+        )
+
+        self.initialize_gui()
+        self.connect_to_labrad("::1")  # only works on localhost.
+
+    def delete_clicked(self, graceful):
+        idx = self.table.selectedIndexes()
+        if idx:
+            row = idx[0].row()
+            rid = self.table_model.row_to_key[row]
+            if graceful:
+                logger.info("Requested termination of RID %d", rid)
+            else:
+                logger.info("Deleted RID %d", rid)
+            asyncio.ensure_future(self.delete(rid, graceful))
+
+    async def connect_subscribers(self):
+        localhost = "::1"
+        port_notify = 3250
+        self._schedule_sub = ModelSubscriber("schedule", schedule.Model, self._report_disconnect)
+        await self._schedule_sub.connect(localhost, port_notify)
+
+    def initialize_gui(self):
+        layout = QtWidgets.QGridLayout()
+        self.table = QtWidgets.QTableView()
+        self.table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
+        self.table.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
+        self.table.verticalHeader().setSectionResizeMode(
+            QtWidgets.QHeaderView.ResizeToContents)
+        self.table.verticalHeader().hide()
+        layout.addWidget(self.table)
+        self.setLayout(layout)
+
+        self.table.setContextMenuPolicy(QtCore.Qt.ActionsContextMenu)
+        request_termination_action = QtWidgets.QAction("Request termination", self.table)
+        request_termination_action.triggered.connect(partial(self.delete_clicked, True))
+        request_termination_action.setShortcut("DELETE")
+        request_termination_action.setShortcutContext(QtCore.Qt.WidgetShortcut)
+        self.table.addAction(request_termination_action)
+        delete_action = QtWidgets.QAction("Delete", self.table)
+        delete_action.triggered.connect(partial(self.delete_clicked, False))
+        delete_action.setShortcut("SHIFT+DELETE")
+        delete_action.setShortcutContext(QtCore.Qt.WidgetShortcut)
+        self.table.addAction(delete_action)
+        terminate_pipeline = QtWidgets.QAction(
+            "Gracefully terminate all in pipeline", self.table)
+        terminate_pipeline.triggered.connect(self.terminate_pipeline_clicked)
+        self.table.addAction(terminate_pipeline)
+
+        self.table_model = schedule.Model(dict())
+        self._schedule_sub.add_setmodel_callback(self.set_model)
+
+        cw = QtGui.QFontMetrics(self.font()).averageCharWidth()
+        h = self.table.horizontalHeader()
+        h.resizeSection(0, 7*cw)
+        h.resizeSection(1, 12*cw)
+        h.resizeSection(2, 16*cw)
+        h.resizeSection(3, 6*cw)
+        h.resizeSection(4, 16*cw)
+        h.resizeSection(5, 30*cw)
+        h.resizeSection(6, 20*cw)
+        h.resizeSection(7, 20*cw)
+
+    async def labrad_connected(self):
+        await self.artiq_connected()
+        await self.setup_cxn_listeners()
+
+    async def setup_cxn_listeners(self):
+        self.cxn.add_on_connect("artiq", self.run_in_labrad_loop(self.artiq_connected))
+        self.cxn.add_on_disconnect("artiq", self.artiq_disconnected)
+
+    async def artiq_connected(self):
+        self.artiq = self.cxn.get_server("artiq")
+        self.setDisabled(False)
+
+    def artiq_disconnected(self):
+        self.setDisabled(True)
+
+    def _report_disconnect(self):
+        if not self._disconnected_reported:
+            logging.error("connection to master lost, restart dashboard to reconnect")
+            self.setDisabled(True)
+        self._disconnect_reported = True
+
+    def set_model(self, model):
+        self.table_model = model
+        self.table.setModel(self.table_model)
+
+    async def delete(self, rid, graceful):
+        if graceful:
+            await self.artiq.request_terminate_experiment(rid)
+        else:
+            await self.artiq.delete_experiment(rid)
+
+    def delete_clicked(self, graceful):
+        idx = self.table.selectedIndexes()
+        if idx:
+            row = idx[0].row()
+            rid = self.table_model.row_to_key[row]
+            if graceful:
+                logger.info("Requested termination of RID %d", rid)
+            else:
+                logger.info("Deleted RID %d", rid)
+            self.run_in_labrad_loop(self.delete)(rid, graceful)
+
+    async def request_term_multiple(self, rids):
+        for rid in rids:
+            try:
+                await self.artiq.request_terminate_experiment(rid)
+            except:
+                # May happen if the experiment has terminated by itself
+                # while we were terminating others.
+                logger.debug("failed to request termination of RID %d",
+                             rid, exc_info=True)
+
+    def terminate_pipeline_clicked(self):
+        idx = self.table.selectedIndexes()
+        if idx:
+            row = idx[0].row()
+            selected_rid = self.table_model.row_to_key[row]
+            pipeline = self.table_model.backing_store[selected_rid]["pipeline"]
+            logger.info("Requesting termination of all "
+                "experiments in pipeline '%s'", pipeline)
+
+            rids = set()
+            for rid, info in self.table_model.backing_store.items():
+                if info["pipeline"] == pipeline:
+                    rids.add(rid)
+            self.run_in_labrad_loop(self.request_term_multiple)(rids)
+
+
+def main():
+    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
+    applet = SimpleApplet(Schedule)
+    applet.run()
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/tools/applets/schedule.py
+++ b/tools/applets/schedule.py
@@ -17,10 +17,21 @@ logger = logging.getLogger(__name__)
 
 
 class Schedule(QtWidgets.QWidget, JaxApplet):
+    """Shows scheduled experiments.
+
+    Modified from artiq.dashboard.schedule.ScheduleDock.
+
+    Experiment can be gracifully terminated if the experiment handles it,
+    or the experiment can be forcefully deleted. When an experiment is terminated
+    or deleted, the preloaded parameters stored in the parameter bank is cleared.
+
+    It also adds context menu options to run the initialization and the background experiments.
+    """
     def __init__(self, args, **kwds):
         super().__init__(**kwds)
         self.setDisabled(True)
 
+        self._disconnect_reported = False
         asyncio.get_event_loop().run_until_complete(
             self.connect_subscribers()  # run in the main thread asyncio loop.
         )
@@ -28,49 +39,21 @@ class Schedule(QtWidgets.QWidget, JaxApplet):
         self.initialize_gui()
         self.connect_to_labrad("::1")  # only works on localhost.
 
-    def delete_clicked(self, graceful):
-        idx = self.table.selectedIndexes()
-        if idx:
-            row = idx[0].row()
-            rid = self.table_model.row_to_key[row]
-            if graceful:
-                logger.info("Requested termination of RID %d", rid)
-            else:
-                logger.info("Deleted RID %d", rid)
-            asyncio.ensure_future(self.delete(rid, graceful))
-
-    async def connect_subscribers(self):
-        localhost = "::1"
-        port_notify = 3250
-        self._schedule_sub = ModelSubscriber("schedule", schedule.Model, self._report_disconnect)
-        await self._schedule_sub.connect(localhost, port_notify)
-
     def initialize_gui(self):
         layout = QtWidgets.QGridLayout()
+        layout.setHorizontalSpacing(0)
+        layout.setVerticalSpacing(0)
         self.table = QtWidgets.QTableView()
         self.table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
         self.table.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
         self.table.verticalHeader().setSectionResizeMode(
             QtWidgets.QHeaderView.ResizeToContents)
         self.table.verticalHeader().hide()
+        self.table.horizontalHeader().setSectionsMovable(True)
         layout.addWidget(self.table)
         self.setLayout(layout)
 
-        self.table.setContextMenuPolicy(QtCore.Qt.ActionsContextMenu)
-        request_termination_action = QtWidgets.QAction("Request termination", self.table)
-        request_termination_action.triggered.connect(partial(self.delete_clicked, True))
-        request_termination_action.setShortcut("DELETE")
-        request_termination_action.setShortcutContext(QtCore.Qt.WidgetShortcut)
-        self.table.addAction(request_termination_action)
-        delete_action = QtWidgets.QAction("Delete", self.table)
-        delete_action.triggered.connect(partial(self.delete_clicked, False))
-        delete_action.setShortcut("SHIFT+DELETE")
-        delete_action.setShortcutContext(QtCore.Qt.WidgetShortcut)
-        self.table.addAction(delete_action)
-        terminate_pipeline = QtWidgets.QAction(
-            "Gracefully terminate all in pipeline", self.table)
-        terminate_pipeline.triggered.connect(self.terminate_pipeline_clicked)
-        self.table.addAction(terminate_pipeline)
+        self._create_context_menu()
 
         self.table_model = schedule.Model(dict())
         self._schedule_sub.add_setmodel_callback(self.set_model)
@@ -86,6 +69,45 @@ class Schedule(QtWidgets.QWidget, JaxApplet):
         h.resizeSection(6, 20*cw)
         h.resizeSection(7, 20*cw)
 
+    def _create_context_menu(self):
+        self.table.setContextMenuPolicy(QtCore.Qt.ActionsContextMenu)
+        request_termination_action = QtWidgets.QAction("Request termination", self.table)
+        request_termination_action.triggered.connect(partial(self.delete_clicked, True))
+        request_termination_action.setShortcut("DELETE")
+        request_termination_action.setShortcutContext(QtCore.Qt.WidgetShortcut)
+        self.table.addAction(request_termination_action)
+
+        delete_action = QtWidgets.QAction("Delete", self.table)
+        delete_action.triggered.connect(partial(self.delete_clicked, False))
+        delete_action.setShortcut("SHIFT+DELETE")
+        delete_action.setShortcutContext(QtCore.Qt.WidgetShortcut)
+        self.table.addAction(delete_action)
+
+        terminate_pipeline = QtWidgets.QAction(
+            "Gracefully terminate all in pipeline", self.table)
+        terminate_pipeline.triggered.connect(self.terminate_pipeline_clicked)
+        self.table.addAction(terminate_pipeline)
+
+        initialization = QtWidgets.QAction("Run initalization experiment", self.table)
+        initialization.triggered.connect(self.run_initialization)
+        self.table.addAction(initialization)
+
+        background = QtWidgets.QAction("Run background experiment", self.table)
+        background.triggered.connect(self.run_background)
+        self.table.addAction(background)
+
+    async def connect_subscribers(self):
+        localhost = "::1"
+        port_notify = 3250
+        self._schedule_sub = ModelSubscriber("schedule", schedule.Model, self._report_disconnect)
+        await self._schedule_sub.connect(localhost, port_notify)
+
+    def _report_disconnect(self):
+        if not self._disconnected_reported:
+            logging.error("connection to master lost, restart dashboard to reconnect")
+            self.setDisabled(True)
+        self._disconnect_reported = True
+
     async def labrad_connected(self):
         await self.artiq_connected()
         await self.setup_cxn_listeners()
@@ -96,22 +118,22 @@ class Schedule(QtWidgets.QWidget, JaxApplet):
 
     async def artiq_connected(self):
         self.artiq = self.cxn.get_server("artiq")
-        self.setDisabled(False)
+        if not self._disconnect_reported:
+            self.setDisabled(False)
 
     def artiq_disconnected(self):
         self.setDisabled(True)
-
-    def _report_disconnect(self):
-        if not self._disconnected_reported:
-            logging.error("connection to master lost, restart dashboard to reconnect")
-            self.setDisabled(True)
-        self._disconnect_reported = True
 
     def set_model(self, model):
         self.table_model = model
         self.table.setModel(self.table_model)
 
     async def delete(self, rid, graceful):
+        """Deletes or terminates an experiment.
+
+        Uses the artiq server functions to delete or to terminate the experiment.
+        The functions also clear the experiment parameters cached in the parameter bank.
+        """
         if graceful:
             await self.artiq.request_terminate_experiment(rid)
         else:
@@ -129,13 +151,14 @@ class Schedule(QtWidgets.QWidget, JaxApplet):
             self.run_in_labrad_loop(self.delete)(rid, graceful)
 
     async def request_term_multiple(self, rids):
+        """Terminates multiple experiments."""
         for rid in rids:
             try:
                 await self.artiq.request_terminate_experiment(rid)
             except:
                 # May happen if the experiment has terminated by itself
                 # while we were terminating others.
-                logger.debug("failed to request termination of RID %d",
+                logger.warning("failed to request termination of RID %d",
                              rid, exc_info=True)
 
     def terminate_pipeline_clicked(self):
@@ -152,6 +175,18 @@ class Schedule(QtWidgets.QWidget, JaxApplet):
                 if info["pipeline"] == pipeline:
                     rids.add(rid)
             self.run_in_labrad_loop(self.request_term_multiple)(rids)
+
+    def run_initialization(self):
+        async def worker():
+            await self.artiq.run_initialization_experiment()
+
+        self.run_in_labrad_loop(worker)()
+
+    def run_background(self):
+        async def worker():
+            await self.artiq.run_background_experiment()
+
+        self.run_in_labrad_loop(worker)()
 
 
 def main():

--- a/tools/applets/schedule.py
+++ b/tools/applets/schedule.py
@@ -157,7 +157,7 @@ class Schedule(QtWidgets.QDockWidget, JaxApplet):
         for rid in rids:
             try:
                 await self.artiq.request_terminate_experiment(rid)
-            except:
+            except Exception as e:
                 # May happen if the experiment has terminated by itself
                 # while we were terminating others.
                 logger.warning(

--- a/tools/dashboard/control_board.py
+++ b/tools/dashboard/control_board.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+
+import argparse
+import asyncio
+import atexit
+import logging
+import os
+
+from artiq import __artiq_dir__ as artiq_dir
+from artiq import __version__ as artiq_version
+from artiq.dashboard import applets_ccb, datasets
+from artiq.gui import log, state
+from artiq.gui.models import ModelSubscriber
+from artiq.tools import get_user_config_dir
+from jax.tools.applets.dds import DDS
+from jax.tools.applets.explorer import Explorer
+from jax.tools.applets.schedule import Schedule
+from PyQt5 import QtCore, QtGui, QtWidgets
+from qasync import QEventLoop
+from sipyco import common_args
+from sipyco.asyncio_tools import atexit_register_coroutine
+from sipyco.broadcast import Receiver
+from sipyco.pc_rpc import Client
+
+
+def get_argparser():
+    parser = argparse.ArgumentParser(description="ARTIQ Control Dashboard")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="ARTIQ v{}".format(artiq_version),
+        help="print the ARTIQ version number",
+    )
+    parser.add_argument(
+        "-s",
+        "--server",
+        default="::1",
+        help="hostname or IP of the master to connect to",
+    )
+    parser.add_argument(
+        "--port-notify",
+        default=3250,
+        type=int,
+        help="TCP port to connect to for notifications",
+    )
+    parser.add_argument(
+        "--port-control",
+        default=3251,
+        type=int,
+        help="TCP port to connect to for control",
+    )
+    parser.add_argument(
+        "--port-broadcast",
+        default=1067,
+        type=int,
+        help="TCP port to connect to for broadcasts",
+    )
+    parser.add_argument(
+        "--db-file", default=None, help="database file for local GUI settings"
+    )
+    common_args.verbosity_args(parser)
+    return parser
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    def __init__(self, server):
+        QtWidgets.QMainWindow.__init__(self)
+
+        # icon = QtGui.QIcon(os.path.join(artiq_dir, "gui", "logo.svg"))
+        # self.setWindowIcon(icon)
+        self.setWindowTitle("ARTIQ Control Dashboard - {}".format(server))
+
+        qfm = QtGui.QFontMetrics(self.font())
+        self.resize(140 * qfm.averageCharWidth(), 38 * qfm.lineSpacing())
+
+        self.exit_request = asyncio.Event()
+
+    def closeEvent(self, event):
+        event.ignore()
+        self.exit_request.set()
+
+    def save_state(self):
+        return {
+            "state": bytes(self.saveState()),
+            "geometry": bytes(self.saveGeometry()),
+        }
+
+    def restore_state(self, state):
+        self.restoreGeometry(QtCore.QByteArray(state["geometry"]))
+        self.restoreState(QtCore.QByteArray(state["state"]))
+
+
+class MdiArea(QtWidgets.QMdiArea):
+    def __init__(self):
+        QtWidgets.QMdiArea.__init__(self)
+
+
+def main():
+    # initialize application
+    args = get_argparser().parse_args()
+    widget_log_handler = log.init_log(args, "dashboard")
+
+    if args.db_file is None:
+        args.db_file = os.path.join(
+            get_user_config_dir(),
+            "artiq_control_dashboard_{server}_{port}.pyon".format(
+                server=args.server.replace(":", "."), port=args.port_notify
+            ),
+        )
+
+    app = QtWidgets.QApplication(["ARTIQ Control Dashboard"])
+    loop = QEventLoop(app)
+    asyncio.set_event_loop(loop)
+    atexit.register(loop.close)
+    smgr = state.StateManager(args.db_file)
+
+    config = Client(args.server, args.port_control, "master_config")
+    try:
+        server_name = config.get_name()
+    finally:
+        config.close_rpc()
+
+    disconnect_reported = False
+
+    def report_disconnect():
+        nonlocal disconnect_reported
+        if not disconnect_reported:
+            logging.error(
+                "connection to master lost, " "restart dashboard to reconnect"
+            )
+        disconnect_reported = True
+
+    sub_clients = dict()
+    for notifier_name, modelf in (("datasets", datasets.Model),):
+        subscriber = ModelSubscriber(notifier_name, modelf, report_disconnect)
+        loop.run_until_complete(subscriber.connect(args.server, args.port_notify))
+        atexit_register_coroutine(subscriber.close)
+        sub_clients[notifier_name] = subscriber
+
+    broadcast_clients = dict()
+    for target in "log", "ccb":
+        client = Receiver(target, [], report_disconnect)
+        loop.run_until_complete(client.connect(args.server, args.port_broadcast))
+        atexit_register_coroutine(client.close)
+        broadcast_clients[target] = client
+
+    # initialize main window
+    main_window = MainWindow(args.server if server_name is None else server_name)
+    smgr.register(main_window)
+    mdi_area = MdiArea()
+    mdi_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
+    mdi_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
+    main_window.setCentralWidget(mdi_area)
+
+    # create UI components
+
+    d_applets = applets_ccb.AppletsCCBDock(main_window, sub_clients["datasets"])
+    atexit_register_coroutine(d_applets.stop)
+    smgr.register(d_applets)
+    broadcast_clients["ccb"].notify_cbs.append(d_applets.ccb_notify)
+
+    logmgr = log.LogDockManager(main_window)
+    smgr.register(logmgr)
+    broadcast_clients["log"].notify_cbs.append(logmgr.append_message)
+    widget_log_handler.callback = logmgr.append_message
+
+    # lay out docks
+    right_docks = [d_applets]
+    main_window.addDockWidget(QtCore.Qt.RightDockWidgetArea, right_docks[0])
+    for d1, d2 in zip(right_docks, right_docks[1:]):
+        main_window.tabifyDockWidget(d1, d2)
+
+    # load/initialize state
+    if os.name == "nt":
+        # HACK: show the main window before creating applets.
+        # Otherwise, the windows of those applets that are in detached
+        # QDockWidgets fail to be embedded.
+        main_window.show()
+    smgr.load()
+    smgr.start()
+    atexit_register_coroutine(smgr.stop)
+
+    # create first log dock if not already in state
+    d_log0 = logmgr.first_log_dock()
+    if d_log0 is not None:
+        main_window.tabifyDockWidget(d_log0)
+
+    if server_name is not None:
+        server_description = server_name + " ({})".format(args.server)
+    else:
+        server_description = args.server
+    logging.info(
+        "ARTIQ dashboard %s connected to %s", artiq_version, server_description
+    )
+
+    # run
+    main_window.show()
+    loop.run_until_complete(main_window.exit_request.wait())
+
+
+if __name__ == "__main__":
+    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
+    main()

--- a/tools/dashboard/plot_board.py
+++ b/tools/dashboard/plot_board.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+
+import argparse
+import asyncio
+import atexit
+import logging
+import os
+
+from artiq import __artiq_dir__ as artiq_dir
+from artiq import __version__ as artiq_version
+from artiq.dashboard import applets_ccb, datasets
+from artiq.gui import log, state
+from artiq.gui.models import ModelSubscriber
+from artiq.tools import get_user_config_dir
+from jax.tools.applets.dds import DDS
+from jax.tools.applets.explorer import Explorer
+from jax.tools.applets.schedule import Schedule
+from PyQt5 import QtCore, QtGui, QtWidgets
+from qasync import QEventLoop
+from sipyco import common_args
+from sipyco.asyncio_tools import atexit_register_coroutine
+from sipyco.broadcast import Receiver
+from sipyco.pc_rpc import Client
+
+
+def get_argparser():
+    parser = argparse.ArgumentParser(description="ARTIQ Control Dashboard")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="ARTIQ v{}".format(artiq_version),
+        help="print the ARTIQ version number",
+    )
+    parser.add_argument(
+        "-s",
+        "--server",
+        default="::1",
+        help="hostname or IP of the master to connect to",
+    )
+    parser.add_argument(
+        "--port-notify",
+        default=3250,
+        type=int,
+        help="TCP port to connect to for notifications",
+    )
+    parser.add_argument(
+        "--port-control",
+        default=3251,
+        type=int,
+        help="TCP port to connect to for control",
+    )
+    parser.add_argument(
+        "--port-broadcast",
+        default=1067,
+        type=int,
+        help="TCP port to connect to for broadcasts",
+    )
+    parser.add_argument(
+        "--db-file", default=None, help="database file for local GUI settings"
+    )
+    common_args.verbosity_args(parser)
+    return parser
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    def __init__(self, server):
+        QtWidgets.QMainWindow.__init__(self)
+
+        # icon = QtGui.QIcon(os.path.join(artiq_dir, "gui", "logo.svg"))
+        # self.setWindowIcon(icon)
+        self.setWindowTitle("ARTIQ Plot Dashboard - {}".format(server))
+
+        qfm = QtGui.QFontMetrics(self.font())
+        self.resize(140 * qfm.averageCharWidth(), 38 * qfm.lineSpacing())
+
+        self.exit_request = asyncio.Event()
+
+    def closeEvent(self, event):
+        event.ignore()
+        self.exit_request.set()
+
+    def save_state(self):
+        return {
+            "state": bytes(self.saveState()),
+            "geometry": bytes(self.saveGeometry()),
+        }
+
+    def restore_state(self, state):
+        self.restoreGeometry(QtCore.QByteArray(state["geometry"]))
+        self.restoreState(QtCore.QByteArray(state["state"]))
+
+
+def main():
+    # initialize application
+    args = get_argparser().parse_args()
+    widget_log_handler = log.init_log(args, "dashboard")
+
+    if args.db_file is None:
+        args.db_file = os.path.join(
+            get_user_config_dir(),
+            "artiq_plot_dashboard_{server}_{port}.pyon".format(
+                server=args.server.replace(":", "."), port=args.port_notify
+            ),
+        )
+
+    app = QtWidgets.QApplication(["ARTIQ Plot Dashboard"])
+    loop = QEventLoop(app)
+    asyncio.set_event_loop(loop)
+    atexit.register(loop.close)
+    smgr = state.StateManager(args.db_file)
+
+    config = Client(args.server, args.port_control, "master_config")
+    try:
+        server_name = config.get_name()
+    finally:
+        config.close_rpc()
+
+    disconnect_reported = False
+
+    def report_disconnect():
+        nonlocal disconnect_reported
+        if not disconnect_reported:
+            logging.error(
+                "connection to master lost, " "restart dashboard to reconnect"
+            )
+        disconnect_reported = True
+
+    sub_clients = dict()
+    for notifier_name, modelf in (("datasets", datasets.Model),):
+        subscriber = ModelSubscriber(notifier_name, modelf, report_disconnect)
+        loop.run_until_complete(subscriber.connect(args.server, args.port_notify))
+        atexit_register_coroutine(subscriber.close)
+        sub_clients[notifier_name] = subscriber
+
+    broadcast_clients = dict()
+    for target in "log", "ccb":
+        client = Receiver(target, [], report_disconnect)
+        loop.run_until_complete(client.connect(args.server, args.port_broadcast))
+        atexit_register_coroutine(client.close)
+        broadcast_clients[target] = client
+
+    # initialize main window
+    main_window = MainWindow(args.server if server_name is None else server_name)
+    smgr.register(main_window)
+
+    # create UI components
+
+    d_applets = applets_ccb.AppletsCCBDock(main_window, sub_clients["datasets"])
+    atexit_register_coroutine(d_applets.stop)
+    smgr.register(d_applets)
+    broadcast_clients["ccb"].notify_cbs.append(d_applets.ccb_notify)
+
+    logmgr = log.LogDockManager(main_window)
+    smgr.register(logmgr)
+    broadcast_clients["log"].notify_cbs.append(logmgr.append_message)
+    widget_log_handler.callback = logmgr.append_message
+
+    # lay out docks
+    right_docks = [d_applets]
+    main_window.addDockWidget(QtCore.Qt.RightDockWidgetArea, right_docks[0])
+    for d1, d2 in zip(right_docks, right_docks[1:]):
+        main_window.tabifyDockWidget(d1, d2)
+
+    # load/initialize state
+    if os.name == "nt":
+        # HACK: show the main window before creating applets.
+        # Otherwise, the windows of those applets that are in detached
+        # QDockWidgets fail to be embedded.
+        main_window.show()
+    smgr.load()
+    smgr.start()
+    atexit_register_coroutine(smgr.stop)
+
+    # create first log dock if not already in state
+    d_log0 = logmgr.first_log_dock()
+    if d_log0 is not None:
+        main_window.tabifyDockWidget(d_log0)
+
+    if server_name is not None:
+        server_description = server_name + " ({})".format(args.server)
+    else:
+        server_description = args.server
+    logging.info(
+        "ARTIQ dashboard %s connected to %s", artiq_version, server_description
+    )
+
+    # run
+    main_window.show()
+    loop.run_until_complete(main_window.exit_request.wait())
+
+
+if __name__ == "__main__":
+    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
+    main()


### PR DESCRIPTION
Partially addresses #48. This PR depends on https://github.com/Jayich-Lab/pydux/pull/1942.

List of changes:
* Adds modified versions of the experiment explorer and the scheduler (originally in artiq) to jax.tools.applets. These applets are designed to work with the artiq and the parameter bank servers.
  - By default, experiments now use parameters when they are scheduled (preload parameters), rather than when they are prepared (previous behavior). This can be overridden by right-click on the experiment and go to details. The preloaded parameters are temporarily saved in the parameter bank before the experiment queries the parameters. If they are stopped through the experiment schedule GUI, the temporarily saved parameter cache is cleared too.
  - Adds a function to scan the device database in the experiment explorer. This should be used with caution. If the device names are changed, you may need to run the initialization experiment again and restart the dds applet.
  - Allows running the initialization and the background experiments by right-clicking in the experiment schedule GUI.
  - Adds a `parameters_updated` signal in the explorer, so the parameter bank *can* use this signal to show only relevant parameters (also see comments later).
* Modifies the parameter loading function in `JaxEnvironment` to support preloading parameters.
* Adds `jax.tools.dashboard.control_board` and `jax.tools.dashboard.plot_board`. The only difference between them is how the applets are organized in the board. The control board centers a small blank area, which allows us to place applets around it like before. The ARTIQ logo was removed from the blank area. The plot board does not have the blank area for maximizing the space to display the plots. See attached screenshots.
* Modifies the DDS applet for visual changes. It should work better for high DPI windows now.
* PMT applet code style change.

This PR closes the first issue in #48 (experiment uses the parameters when scheduled), and makes addressing most of the other issues in #48 easier. However, this PR does not fully allow addressing synchronizing the experiment selected in the explorer and the parameters in the parameter bank. We will need the two applets to directly talk to each other (initializing them in the control board) for that. However, this is blocked by how we implement labrad with applets, as we cannot run multiple reactors in a single program while these applets want to make separate labrad connections. This can be solved by implementing labrad differently, but it is probably better to skip this issue for now.