### PR TITLE
scans the repository when explorer starts

### DIFF
--- a/tools/applets/explorer.py
+++ b/tools/applets/explorer.py
@@ -252,6 +252,7 @@ class Explorer(QtWidgets.QDockWidget, JaxApplet):
         ExamineDeviceMgr.get_device_db = lambda: self.device_db
         self.repo_path = await self.artiq.get_repository_path()
 
+        await self.artiq.scan_experiment_repository(True)
         if not self._parameters_initialized:
             self._get_all_experiment_parameters()
             self._parameters_initialized = True


### PR DESCRIPTION
Fixes a bug that makes the explorer unable to be started. If an experiment is loaded in the explorer, and the experiment code is deleted without scanning, the explorer cannot be started again.