### PR TITLE
fixes bug in `sync_time` in the drift tracker

### DIFF
--- a/tools/applets/explorer.py
+++ b/tools/applets/explorer.py
@@ -252,6 +252,7 @@ class Explorer(QtWidgets.QDockWidget, JaxApplet):
         ExamineDeviceMgr.get_device_db = lambda: self.device_db
         self.repo_path = await self.artiq.get_repository_path()
 
+        await self.artiq.scan_experiment_repository(True)
         if not self._parameters_initialized:
             self._get_all_experiment_parameters()
             self._parameters_initialized = True

--- a/util/drift_tracker.py
+++ b/util/drift_tracker.py
@@ -62,28 +62,19 @@ class DriftTracker:
         self.uB_over_h = _c.physical_constants["Bohr magneton"][0] / _c.h
 
     @kernel(flags={"fast-math"})
-    def seconds_to_mu(self, time_seconds: TFloat):
-        """TODO: move this function of the module, or eliminate the magic number 1e-9 here."""
-        return _np.int64(time_seconds // 1e-9)
-
-    @kernel(flags={"fast-math"})
-    def mu_to_seconds(self, time_mu: TInt64):
-        """TODO: move this function of the module, or eliminate the magic number 1e-9 here."""
-        return time_mu * 1e-9
-
-    @kernel(flags={"fast-math"})
-    def sync_time(self, time_now):
+    def sync_time(self, time_now: TFloat, mu: TFloat=1e-9):
         """Syncs wall clock time with core device time.
 
         Must be called if self.get_frequency_kernel or self.get_Zeeman_frequency_kernel are used.
 
         Args:
             time_now: float, epoch time now.
+            mu: float, machine unit of time in s. Default 1e-9 (1 ns).
         """
         time_after_calibration = time_now - self.last_calibration
-        self._last_calibration_mu = now_mu() - self.seconds_to_mu(time_after_calibration)
+        self._last_calibration_mu = now_mu() - _np.int64(time_after_calibration / mu)
         # time is converted to machine units, frequency is still in Hz.
-        self._center_drift_rate_mu = self.center_drift_rate * self.mu_to_seconds(1)
+        self._center_drift_rate_mu = self.center_drift_rate * mu
 
     @host_only
     def get_frequency_host(self, detuning):

--- a/util/drift_tracker.py
+++ b/util/drift_tracker.py
@@ -61,16 +61,24 @@ class DriftTracker:
         self._center_drift_rate_mu = 0.
         self.uB_over_h = _c.physical_constants["Bohr magneton"][0] / _c.h
 
+    @rpc
+    def get_epoch_time(self) -> TFloat:
+        """Returns the current epoch time in seconds."""
+        return _t.time()
+
     @kernel(flags={"fast-math"})
-    def sync_time(self, time_now: TFloat, mu: TFloat = 1e-9):
+    def sync_time(self, mu: TFloat = 1e-9):
         """Syncs wall clock time with core device time.
 
-        Must be called if self.get_frequency_kernel or self.get_Zeeman_frequency_kernel are used.
+        This function sets the drift rate and calibration time in machine units.
+        It needs to be called once before `get_frequency_kernel` or `get_Zeeman_frequency_kernel`
+        is used. This function contains a remote procedure call so it may be slow.
 
         Args:
             time_now: float, epoch time now.
             mu: float, machine unit of time in s. Default 1e-9 (1 ns).
         """
+        time_now = self.get_epoch_time()
         time_after_calibration = time_now - self.last_calibration
         self._last_calibration_mu = now_mu() - _np.int64(time_after_calibration / mu)
         # time is converted to machine units, frequency is still in Hz.

--- a/util/drift_tracker.py
+++ b/util/drift_tracker.py
@@ -62,6 +62,16 @@ class DriftTracker:
         self.uB_over_h = _c.physical_constants["Bohr magneton"][0] / _c.h
 
     @kernel(flags={"fast-math"})
+    def seconds_to_mu(self, time_seconds: TFloat):
+        """TODO: move this function of the module, or eliminate the magic number 1e-9 here."""
+        return _np.int64(time_seconds // 1e-9)
+
+    @kernel(flags={"fast-math"})
+    def mu_to_seconds(self, time_mu: TInt64):
+        """TODO: move this function of the module, or eliminate the magic number 1e-9 here."""
+        return time_mu * 1e-9
+
+    @kernel(flags={"fast-math"})
     def sync_time(self, time_now):
         """Syncs wall clock time with core device time.
 
@@ -71,9 +81,9 @@ class DriftTracker:
             time_now: float, epoch time now.
         """
         time_after_calibration = time_now - self.last_calibration
-        self._last_calibration_mu = now_mu() - self.core.seconds_to_mu(time_after_calibration)
+        self._last_calibration_mu = now_mu() - self.seconds_to_mu(time_after_calibration)
         # time is converted to machine units, frequency is still in Hz.
-        self._center_drift_rate_mu = self.center_drift_rate * self.core.mu_to_seconds(1)
+        self._center_drift_rate_mu = self.center_drift_rate * self.mu_to_seconds(1)
 
     @host_only
     def get_frequency_host(self, detuning):

--- a/util/drift_tracker.py
+++ b/util/drift_tracker.py
@@ -62,7 +62,7 @@ class DriftTracker:
         self.uB_over_h = _c.physical_constants["Bohr magneton"][0] / _c.h
 
     @kernel(flags={"fast-math"})
-    def sync_time(self, time_now: TFloat, mu: TFloat=1e-9):
+    def sync_time(self, time_now: TFloat, mu: TFloat = 1e-9):
         """Syncs wall clock time with core device time.
 
         Must be called if self.get_frequency_kernel or self.get_Zeeman_frequency_kernel are used.


### PR DESCRIPTION
Now `sync_time` should work. Machine unit of time is set to 1 ns, which is the case for all current artiq devices. For future devices that may use a different machine unit, `mu` should be set to the new machine unit value.

This code is untested. If the clock experiment runs, this code should work.