### PR TITLE
Add AD9910 RAM Mode Example

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -5,5 +5,5 @@ from jax.base.environments.sinara_environment import SinaraEnvironment
 from jax.base.experiments.jax_experiment import JaxExperiment
 from jax.base.experiments.scan import Scan
 from jax.base.experiments.infinite_loop import InfiniteLoop
-from jax.base.experiments.ad9910_ram import AD9910RAM, RAMType, RAMProfile, RAMProfileMap
+from jax.base.experiments.ad9910_ram import RAMType, RAMProfile, RAMProfileMap
 from jax.base.sequences.sequence import Sequence

--- a/__init__.py
+++ b/__init__.py
@@ -5,4 +5,5 @@ from jax.base.environments.sinara_environment import SinaraEnvironment
 from jax.base.experiments.jax_experiment import JaxExperiment
 from jax.base.experiments.scan import Scan
 from jax.base.experiments.infinite_loop import InfiniteLoop
+from jax.base.experiments.ad9910_ram import AD9910RAM, RAMType, RAMProfile, RAMProfileMap
 from jax.base.sequences.sequence import Sequence

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -30,7 +30,7 @@ class RAMType(Enum):
 class RAMProfile:
     RAM_SIZE = 1024
 
-    def __init__(self, dds, data, ramp_interval, ram_type, ramp_mode,
+    def __init__(self, dds, data, ramp_interval, ram_type, ram_mode,
                  base_frequency=0, base_phase=0, base_amplitude=0):
         """Generate a RAM profile to a DDS channel.
             Include optional parameters based on the "Data Source Priority" of
@@ -110,7 +110,7 @@ class RAMProfile:
         # Note: Integer conversion may cause inaccuracy
         self.step = int(ramp_interval * dds.sysclk / 4.0)
 
-        self.ramp_mode = ramp_mode
+        self.ram_mode = ram_mode
 
 
 class RAMProfileMap:
@@ -164,7 +164,7 @@ class RAMProfileMap:
                 start=ram_profile.start_addr,
                 end=ram_profile.end_addr,
                 step=ram_profile.step,
-                mode=ram_profile.ramp_mode)
+                mode=ram_profile.ram_mode)
             dds.cpld.io_update.pulse_mu(8)
 
             # Program the RAM, break_realtime to avoid RTIOunderflow

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -219,13 +219,13 @@ class RAMProfileMap:
         It initializes the RAM content and profiles.
 
         Timing: (Figures generated using Kasli 2.0, 1024 RAM entries, 1 DDS)
-            The entire write_ram() call is measured to have taken ~600 us
+            The entire load_ram() call is measured to have taken ~620 us
             (omitting the wasted cycles due to the RTIO FIFO being filled up).
             The difference between the RTIO timestamp cursor and the RTIO
             counter (slack) reduced by ~50 us (with the same omission).
 
             The omission was applied since providing excessive slack will only
-            result in wasted clock cycles. write_ram() will hang and waste
+            result in wasted clock cycles. load_ram() will hang and waste
             clock cycles if the RTIO FIFO is saturated. No more RTIO events
             could be submitted until some of these events are executed, which
             frees up the FIFO.

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -273,7 +273,8 @@ class RAMProfileMap:
 
     @kernel
     def commit_enable(self):
-        """Commit the previous enable() call.
+        """Commit the previous enable() call. The RAM profile will always
+            start from the designated first address.
 
         """
         # Start RAM mode using the same profile switch update.

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -137,31 +137,30 @@ class RAMProfile:
         self.ftw, self.pow, self.asf = 0, 0, 0x3fff
 
         # Encode the FTW, POW, ASF, and raw data en masse
-        match ram_type:
-            case RAMType.FREQ:
-                self.dest = RAM_DEST_FTW
-                dds.frequency_to_ram(data, ram)
-                self.asf = dds.amplitude_to_asf(base_amplitude)
-                self.pow = dds.turns_to_pow(base_phase)
-            case RAMType.PHASE:
-                self.dest = RAM_DEST_POW
-                dds.turns_to_ram(data, ram)
-                self.ftw = dds.frequency_to_ftw(base_frequency)
-                self.asf = dds.amplitude_to_asf(base_amplitude)
-            case RAMType.AMP:
-                self.dest = RAM_DEST_ASF
-                dds.amplitude_to_ram(data, ram)
-                self.ftw = dds.frequency_to_ftw(base_frequency)
-                self.pow = dds.turns_to_pow(base_phase)
-            case RAMType.POLAR:
-                self.dest = RAM_DEST_POWASF
-                # Unpack the list of tuples into tuples
-                # Zip it again to convert it into 2 lists
-                phase, amp = zip(*data)
-                dds.turns_amplitude_to_ram(phase, amp, ram)
-                self.ftw = dds.frequency_to_ftw(base_frequency)
-            case _:
-                raise NotImplementedError
+        if ram_type == RAMType.FREQ:
+            self.dest = RAM_DEST_FTW
+            dds.frequency_to_ram(data, ram)
+            self.asf = dds.amplitude_to_asf(base_amplitude)
+            self.pow = dds.turns_to_pow(base_phase)
+        elif ram_type == RAMType.PHASE:
+            self.dest = RAM_DEST_POW
+            dds.turns_to_ram(data, ram)
+            self.ftw = dds.frequency_to_ftw(base_frequency)
+            self.asf = dds.amplitude_to_asf(base_amplitude)
+        elif ram_type == RAMType.AMP:
+            self.dest = RAM_DEST_ASF
+            dds.amplitude_to_ram(data, ram)
+            self.ftw = dds.frequency_to_ftw(base_frequency)
+            self.pow = dds.turns_to_pow(base_phase)
+        elif ram_type == RAMType.POLAR:
+            self.dest = RAM_DEST_POWASF
+            # Unpack the list of tuples into tuples
+            # Zip it again to convert it into 2 lists
+            phase, amp = zip(*data)
+            dds.turns_amplitude_to_ram(phase, amp, ram)
+            self.ftw = dds.frequency_to_ftw(base_frequency)
+        else:
+            raise NotImplementedError
 
         self.start_addr = 0
         self.end_addr = len(ram) - 1    # Inclusive

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -87,7 +87,7 @@ class RAMProfile:
         # Make sure the RAM can hold the entire sequence
         assert (len(data) <= RAMProfile.RAM_SIZE)
 
-        ram = np.zeros((len(data),), dtype=int)
+        ram = np.zeros((len(data),), dtype=np.int32)
         # Avoid contaminating the passed in data list
         data = data.copy()
         # SPI transaction of AD9910 mandates the transmission of higher

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -177,6 +177,11 @@ class RAMProfileMap:
                        asf=ram_profile.asf,
                        ram_destination=ram_profile.dest)
 
+        # Go back to single-tone profiles
+        # This is to ensure the symmetry of states, so enabling and disabling
+        # RAM profiles is logically sound
+        for cpld in self.cplds:
+            cpld.set_profile(7)
         # Queue in RAM enable operations to each DDS
         for dds, ram_profile in self.ram_profile_map:
             dds.set_cfr1(ram_enable=1,

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -73,8 +73,11 @@ class RAMProfile:
             ram_mode (int): The playback mode of the RAM.
                 See coredevice/ad9910.py in ARTIQ.
             base_frequency (float): (Optional) Unmodulated DDS frequency.
+                0.0 Hz by default.
             base_phase (float): (Optional) Unmodulated DDS phase.
+                0.0 turns by default.
             base_amplitude (float): (Optional) Unmodulated DDS amplitude.
+                1.0 by default.
 
         Raises:
             NotImplementedError: Unsupported RAM types found.

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -177,6 +177,22 @@ class RAMProfileMap:
     def load_ram(self):
         """Load RAM operation. It initializes the RAM content and profiles.
 
+        Timing: (Figures generated using Kasli 2.0, 1024 RAM entries, 1 DDS)
+            The entire write_ram() call is measured to have taken ~600 us
+            (omitting the wasted cycles due to the RTIO FIFO being filled up).
+            The difference between the RTIO timestamp cursor and the RTIO
+            counter (slack) reduced by ~50 us (with the same omission).
+
+            The omission was applied since providing excessive slack will only
+            result in wasted clock cycles. write_ram() will hang and waste
+            clock cycles if the RTIO FIFO is saturated. No more RTIO events
+            could be submitted until some of these events are executed, which
+            frees up the FIFO.
+
+            Each RAM entry contributes to the slack loss. From experimentation
+            and generalization, the first 127 RAM entries each contributes
+            approximately ~60 ns of slack los on average. The rest of the RAM
+            entries each contributes to ~40 ns of slack loss on average.
         """
         # Switch to profile 0 for RAM. This is the default profile.
         # Using other profiles for RAM is possible with appropriate parameters

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -1,6 +1,5 @@
 from artiq.experiment import *
 from artiq.coredevice.ad9910 import *
-from jax import JaxExperiment
 import numpy as np
 from enum import Enum
 

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -53,7 +53,7 @@ class RAMProfile:
             NotImplementedError: Unsupported RAM types found.
         """
         # Make sure the RAM can hold the entire sequence
-        assert(len(data) <= RAMProfile.RAM_SIZE)
+        assert (len(data) <= RAMProfile.RAM_SIZE)
 
         ram = np.zeros((len(data),), dtype=int)
         # Avoid contaminating the passed in data list

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -28,87 +28,99 @@ class RAMType(Enum):
 
 
 class RAMProfile:
-    """RAM profile is an operation mode that feeds RAM data into the DDS as
-        DDS parameter(s) (frequency/phase/amplitude). At an user-defined time
-        interval, the DDS fetches a new RAM data and updates the selected
-        parameter. See the arguments of the constructor (__init__(..)) to tune
-        the interval, DDS parameter and data selection of the RAM playback.
+    """A RAM profile of a DDS channel.
 
-        All RAM profiles in the same AD9910 has access to the same 1024 x
-        32-bits RAM. There are 1024 entries, each entry occupies 32-bits.
+    RAM profile is an operation mode that feeds RAM data into the DDS as DDS
+    parameter(s) (frequency/phase/amplitude). At an user-defined time interval,
+    the DDS fetches a new RAM data and updates the selected parameter. See the
+    arguments of the constructor (__init__(..)) to tune the interval, DDS
+    parameter and data selection of the RAM playback.
+
+    All RAM profiles in the same AD9910 has access to the same 1024 x 32-bits
+    RAM. There are 1024 entries, each entry occupies 32-bits.
+
+    Unlike single-tone profiles, RAM profiles only specifies a subset of
+    parameters. The remaining parameters are specified through the FTW/POW/ASF
+    registers instead (See args base_frequency, base_phase, base_amplitude).
+    Note that unnecessary parameters will be ignored.
+
+    For example, a frequency RAM profile feeds RAM as frequencies. Phase and
+    amplitude are specified through POW and ASF registers respectively. These
+    registers are controlled by the base_phase and base_amplitude args.
+
+    Reference: AD9910 datasheet (Rev. E), Theory of Operation, Mode Priority,
+    Table 5: Data Source Priority
+
+    Note: There are different data latencies between different RAM types.
+    Amplitude takes 36 fewer sysclk cycles to reach the DDS output. Refer to
+    AD9910 datasheet (Rev. E) p.6, Data Latency.
+
+    Attributes:
+        ftw: int, the frequency tuning word for the FTW register.
+        pow: int, the phase offset word for the POW register.
+        asf: int, the amplitude scale factor for the ASF register.
+        dest: int, the RAM data destination.
+        start_addr: int, the starting RAM address of the RAM profile.
+        end_addr: int, the ending (last) RAM address of the RAM profile.
+        osk_enable: int, enable/disable OSK for the RAM profile if 1/0.
+        ram: list of int, encoded data for the RAM.
+        step: int, the number of sysclk cycles per RAM step.
+        ram_mode: int, the playback mode of the RAM.
+
+    Args:
+        dds: AD9910, the DDS that will playback the RAM profile.
+        data: list of float/2-tuples (elaborated below), the data (amplitude,
+            phase, frequencies) to be put into the RAM.
+            The type should be "list of float" for frequency/phase/amplitude
+            RAM; and list of 2-tuples for polar RAM. The tuple consists of 2
+            floats. The first represents phase, and the second represents
+            amplitude.
+        ramp_interval: float, the time interval between each step of the RAM
+            mode playback. Keep the interval at a multiple of 4*T_sysclk
+            (4*1 ns).
+        ram_type: RAMType, see the RAMType enum.
+        ram_mode: int, the playback mode of the RAM. AD9910 allows the
+            following RAM playback modes.
+
+            - RAM_MODE_DIRECTSWITCH:
+                Only the first data in the RAM profile is fed to the DDS
+
+            The other modes can fetch new RAM data to the DDS. The main
+            difference is the behavior once the last data is fetched.
+
+            - RAM_MODE_RAMPUP:
+                DDS will not fetch anything after getting the last data.
+            - RAM_MODE_BIDIR_RAMP:
+                Same as RAM_MODE_RAMPUP. However, an additional ramp down mode
+                is supported by setting profile=1.
+            - RAM_MODE_CONT_BIDIR_RAMP:
+                The RAM profile will ramp down after getting the last data.
+                Then ramp up after getting the first data, and so on.
+            - RAM_MODE_CONT_RAMPUP:
+                The RAM profile will repeat itself after getting the last data
+                from the RAM.
+
+            See the following sections on the datasheet regarding the exact
+            behavior of these 5 modes.
+            - RAM Direct Switch Mode (p.33)
+            - RAM Ramp-Up Mode (p.34, Figure 43)
+            - RAM Bidirectional Ramp Mode (p.38, Figure 46)
+            - RAM Continuous Bidirectional Ramp Mode (p.39, Figure 47)
+            - RAM Continuous Recirculate Mode (p.40, Figure 48)
+        base_frequency: float, the unmodulated DDS frequency.
+            0.0 Hz by default. This argument is optional.
+        base_phase: float, the unmodulated DDS phase.
+            0.0 turns by default. This argument is optional.
+        base_amplitude: float, the unmodulated DDS amplitude.
+            1.0 by default. This argument is optional.
+
+    Raises:
+        NotImplementedError: Unsupported RAM types found.
     """
     RAM_SIZE = 1024
 
     def __init__(self, dds, data, ramp_interval, ram_type, ram_mode,
                  base_frequency=0, base_phase=0, base_amplitude=1.0):
-        """Generate a RAM profile to a DDS channel.
-            Unlike single-tone profiles, RAM profiles only specifies a subset
-            of parameters. The remaining parameters are specified through the
-            FTW/POW/ASF registers instead (See args base_frequency, base_phase,
-            base_amplitude). Note that unnecessary parameters will be ignored.
-
-            For example, a frequency RAM profile feeds RAM as frequencies.
-            Phase and amplitude are specified through POW and ASF registers
-            respectively. These registers are controlled by the base_phase and
-            base_amplitude args.
-
-            Reference: AD9910 datasheet (Rev. E), Theory of Operation, Mode
-            Priority, Table 5: Data Source Priority
-
-            Note: There are different data latencies between different RAM
-            types. Amplitude takes 36 fewer sysclk cycles to reach the DDS
-            output. Refer to AD9910 datasheet (Rev. E) p.6, Data Latency
-
-        Args:
-            dds: AD9910, the DDS that will playback the RAM profile.
-            data: list of float/2-tuples (elaborated below), the data
-                (amplitude, phase, frequencies) to be put into the RAM.
-                The type should be "list of float" for frequency/phase/
-                amplitude RAM; and list of 2-tuples for polar RAM. The tuple
-                consists of 2 floats. The first represents phase, and the
-                second represents amplitude.
-            ramp_interval: float, the time interval between each step of the
-                RAM mode playback. Keep the interval at a multiple of
-                4*T_sysclk (4*1 ns).
-            ram_type: RAMType, see the RAMType enum.
-            ram_mode: int, the playback mode of the RAM. AD9910 allows the
-                following RAM playback modes.
-
-                - RAM_MODE_DIRECTSWITCH:
-                    Only the first data in the RAM profile is fed to the DDS
-
-                The other modes can fetch new RAM data to the DDS. The main
-                difference is the behavior once the last data is fetched.
-
-                - RAM_MODE_RAMPUP:
-                    DDS will not fetch anything after getting the last data.
-                - RAM_MODE_BIDIR_RAMP:
-                    Same as RAM_MODE_RAMPUP. However, an additional ramp down
-                    mode is supported by setting profile=1.
-                - RAM_MODE_CONT_BIDIR_RAMP:
-                    The RAM profile will ramp down after getting the last data.
-                    Then ramp up after getting the first data, and so on.
-                - RAM_MODE_CONT_RAMPUP:
-                    The RAM profile will repeat itself after getting the last
-                    data from the RAM.
-
-                See the following sections on the datasheet regarding the
-                exact behavior of these 5 modes.
-                - RAM Direct Switch Mode (p.33)
-                - RAM Ramp-Up Mode (p.34, Figure 43)
-                - RAM Bidirectional Ramp Mode (p.38, Figure 46)
-                - RAM Continuous Bidirectional Ramp Mode (p.39, Figure 47)
-                - RAM Continuous Recirculate Mode (p.40, Figure 48)
-            base_frequency: float, the unmodulated DDS frequency.
-                0.0 Hz by default. This argument is optional.
-            base_phase: float, the unmodulated DDS phase.
-                0.0 turns by default. This argument is optional.
-            base_amplitude: float, the unmodulated DDS amplitude.
-                1.0 by default. This argument is optional.
-
-        Raises:
-            NotImplementedError: Unsupported RAM types found.
-        """
         # Make sure the RAM can hold the entire sequence
         assert (len(data) <= RAMProfile.RAM_SIZE)
 
@@ -171,19 +183,18 @@ class RAMProfile:
 
 
 class RAMProfileMap:
-    def __init__(self, core):
-        """Initialize a RAM profile to DDS mapping
+    """A mapping between RAM profiles and the DDS that performs the playback.
 
-        Args:
-            core: Core, the ARTIQ Core instance for time control.
-        """
-        self.ram_profile_map = []
-        self.cplds = []
-        self.core = core
+    Args:
+        core: Core, the ARTIQ Core instance for time control.
+    """
+    def __init__(self, core):
 
     def append(self, dds, ram_profile):
-        """Append a RAM profile into the builder. In addition, register the
-            CPLDs that have DDSes that playback the RAM profile.
+        """Append a RAM profile into the builder.
+
+        In addition, register the CPLDs that have DDSes that playback the RAM
+        profile.
 
         Args:
             dds: AD9910, the DDS that will playback the RAM profile.
@@ -201,7 +212,9 @@ class RAMProfileMap:
 
     @kernel
     def load_ram(self):
-        """Load RAM operation. It initializes the RAM content and profiles.
+        """Load RAM operation.
+
+        It initializes the RAM content and profiles.
 
         Timing: (Figures generated using Kasli 2.0, 1024 RAM entries, 1 DDS)
             The entire write_ram() call is measured to have taken ~600 us
@@ -261,9 +274,9 @@ class RAMProfileMap:
     @kernel
     def enable(self):
         """Set register appropriately for enabling RAM mode.
-            After the function is called. RAM mode is NOT YET active.
-            Commit RAM enable by calling commit_enable() after.
 
+        After the function is called. RAM mode is NOT YET active.
+        Commit RAM enable by calling commit_enable() after.
         """
         # Queue in RAM enable operations to each DDS
         for dds, ram_profile in self.ram_profile_map:
@@ -275,7 +288,6 @@ class RAMProfileMap:
     def commit_enable(self):
         """Commit the previous enable() call. The RAM profile will always
             start from the designated first address.
-
         """
         # Start RAM mode using the same profile switch update.
         # This is achieved by invoking SPI transactions in the same timestamp.
@@ -289,9 +301,9 @@ class RAMProfileMap:
     @kernel
     def disable(self):
         """Set register appropriately for disabling RAM mode.
-            After the function is called. RAM mode is STILL active.
-            Commit RAM disable by calling commit_disable() after.
 
+        After the function is called. RAM mode is STILL active. Commit RAM
+        disable by calling commit_disable() after.
         """
         for dds, _ in self.ram_profile_map:
             # Disable RAM and OSK.
@@ -302,9 +314,9 @@ class RAMProfileMap:
     @kernel
     def commit_disable(self):
         """Commit the previous disable() call.
-            After this call has taken effect (in terms of the ARTIQ timeline),
-            single-tone profiles are enabled instead.
 
+        After this call has taken effect (in terms of the ARTIQ timeline),
+        single-tone profiles are enabled instead.
         """
         # End RAM mode using the same profile switch update.
         # This is achieved by invoking SPI transactions in the same timestamp.

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -129,8 +129,7 @@ class RAMProfile:
         self.start_addr = 0
         self.end_addr = len(ram) - 1    # Inclusive
 
-        # Configure ther use of OSK. Note that using different OSK settings for
-        # different channels introduces step swiching latencies
+        # Configure the use of OSK.
         if ram_type == RAMType.AMP or ram_type == RAMType.POLAR:
             # Disable OSK. OSK amplitude as it has a higher priority than RAM.
             self.osk_enable = 0
@@ -138,10 +137,9 @@ class RAMProfile:
             # Enable OSK. There are no other utilizable amplitude data source.
             self.osk_enable = 1
 
-        # Conversion to list to avoid type mismatch in the kernel
-        self.ram = ram.tolist()
+        # Conversion to a list of numpy int32 to avoid type inference.
+        self.ram = list(ram)
 
-        # Note: Integer conversion may cause inaccuracy
         self.step = int(ramp_interval * dds.sysclk / 4.0)
 
         self.ram_mode = ram_mode

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -61,24 +61,25 @@ class RAMProfile:
             output. Refer to AD9910 datasheet (Rev. E) p.6, Data Latency
 
         Args:
-            dds (AD9910): The DDS that will playback the RAM profile.
-            data ([..]): Data (amplitude, phase, frequencies) to be put into
-                the RAM.
-                The type should be [float] for frequency/phase/amplitude RAM;
-                and [(phase (float), amplitude (float))] for polar RAM.
-                (Sanity check: It is a list of tuples for polar RAM.)
-            ramp_interval (float): The time interval between each step of the
+            dds: AD9910, the DDS that will playback the RAM profile.
+            data: list of float/2-tuples (elaborated below), the data
+                (amplitude, phase, frequencies) to be put into the RAM.
+                The type should be "list of float" for frequency/phase/
+                amplitude RAM; and list of 2-tuples for polar RAM. The tuple
+                consists of 2 floats. The first represents phase, and the
+                second represents amplitude.
+            ramp_interval: float, the time interval between each step of the
                 RAM mode playback. Keep the interval at a multiple of
                 4*T_sysclk (4*1 ns).
-            ram_type (RAMType): See the RAMType enum.
-            ram_mode (int): The playback mode of the RAM.
+            ram_type: RAMType, see the RAMType enum.
+            ram_mode: int, the playback mode of the RAM.
                 See coredevice/ad9910.py in ARTIQ.
-            base_frequency (float): (Optional) Unmodulated DDS frequency.
-                0.0 Hz by default.
-            base_phase (float): (Optional) Unmodulated DDS phase.
-                0.0 turns by default.
-            base_amplitude (float): (Optional) Unmodulated DDS amplitude.
-                1.0 by default.
+            base_frequency: float, the unmodulated DDS frequency.
+                0.0 Hz by default. This argument is optional.
+            base_phase: float, the unmodulated DDS phase.
+                0.0 turns by default. This argument is optional.
+            base_amplitude: float, the unmodulated DDS amplitude.
+                1.0 by default. This argument is optional.
 
         Raises:
             NotImplementedError: Unsupported RAM types found.
@@ -151,7 +152,7 @@ class RAMProfileMap:
         """Initialize a RAM profile to DDS mapping
 
         Args:
-            core: The ARTIQ Core instance for time control.
+            core: Core, the ARTIQ Core instance for time control.
         """
         self.ram_profile_map = []
         self.cplds = []
@@ -162,8 +163,8 @@ class RAMProfileMap:
             CPLDs that have DDSes that playback the RAM profile.
 
         Args:
-            dds: The DDS that will playback the RAM profile.
-            ram_profile: The RAM profile.
+            dds: AD9910, the DDS that will playback the RAM profile.
+            ram_profile: RAMProfile, the RAM profile.
         """
         self.ram_profile_map.append((dds, ram_profile))
 

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -46,7 +46,7 @@ class RAMProfile:
             Unlike single-tone profiles, RAM profiles only specifies a subset
             of parameters. The remaining parameters are specified through the
             FTW/POW/ASF registers instead (See args base_frequency, base_phase,
-            base_amplitude). Note that unnecessary paramters will be ignored.
+            base_amplitude). Note that unnecessary parameters will be ignored.
 
             For example, a frequency RAM profile feeds RAM as frequencies.
             Phase and amplitude are specified through POW and ASF registers
@@ -118,7 +118,7 @@ class RAMProfile:
                 self.pow = dds.turns_to_pow(base_phase)
             case RAMType.POLAR:
                 self.dest = RAM_DEST_POWASF
-                # Unpack the lsit of tuples into tuples
+                # Unpack the list of tuples into tuples
                 # Zip it again to convert it into 2 lists
                 phase, amp = zip(*data)
                 dds.turns_amplitude_to_ram(phase, amp, ram)
@@ -168,8 +168,8 @@ class RAMProfileMap:
         """
         self.ram_profile_map.append((dds, ram_profile))
 
-        # Add the associlated CPLD to the list if not already there.
-        # ARTIQ-Python does not support iterration of a Python builtin set
+        # Add the associated CPLD to the list if not already there.
+        # ARTIQ-Python does not support iteration of a Python builtin set
         # The workaround is to maintain a list, but convert it into set to
         # avoid CPLD duplications.
         cplds = set(self.cplds)
@@ -188,7 +188,7 @@ class RAMProfileMap:
             cpld.set_profile(0)
 
         for dds, ram_profile in self.ram_profile_map:
-            # Datasheets strongly recommands setting ram_enable=0 before
+            # The datasheet strongly recommends setting ram_enable=0 before
             # writing anything to the RAM profiles
             dds.set_cfr1(ram_enable=0)
             dds.cpld.io_update.pulse_mu(8)
@@ -201,7 +201,7 @@ class RAMProfileMap:
                 mode=ram_profile.ram_mode)
             dds.cpld.io_update.pulse_mu(8)
 
-            # Program the RAM, break_realtime to avoid RTIOunderflow
+            # Program the RAM, break_realtime to avoid RTIOUnderflow
             dds.write_ram(ram_profile.ram)
             self.core.break_realtime()
 
@@ -250,7 +250,7 @@ class RAMProfileMap:
     def disable(self):
         """Set register appropriately for disabling RAM mode.
             After the function is called. RAM mode is STILL active.
-            Commit RAM disable by calling commit_enable() after.
+            Commit RAM disable by calling commit_disable() after.
 
         """
         for dds, _ in self.ram_profile_map:

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -71,8 +71,34 @@ class RAMProfile:
                 RAM mode playback. Keep the interval at a multiple of
                 4*T_sysclk (4*1 ns).
             ram_type: RAMType, see the RAMType enum.
-            ram_mode: int, the playback mode of the RAM.
-                See coredevice/ad9910.py in ARTIQ.
+            ram_mode: int, the playback mode of the RAM. AD9910 allows the
+                following RAM playback modes.
+
+                - RAM_MODE_DIRECTSWITCH:
+                    Only the first data in the RAM profile is fed to the DDS
+
+                The other modes can fetch new RAM data to the DDS. The main
+                difference is the behavior once the last data is fetched.
+
+                - RAM_MODE_RAMPUP:
+                    DDS will not fetch anything after getting the last data.
+                - RAM_MODE_BIDIR_RAMP:
+                    Same as RAM_MODE_RAMPUP. However, an additional ramp down
+                    mode is supported by setting profile=1.
+                - RAM_MODE_CONT_BIDIR_RAMP:
+                    The RAM profile will ramp down after getting the last data.
+                    Then ramp up after getting the first data, and so on.
+                - RAM_MODE_CONT_RAMPUP:
+                    The RAM profile will repeat itself after getting the last
+                    data from the RAM.
+
+                See the following sections on the datasheet regarding the
+                exact behavior of these 5 modes.
+                - RAM Direct Switch Mode (p.33)
+                - RAM Ramp-Up Mode (p.34, Figure 43)
+                - RAM Bidirectional Ramp Mode (p.38, Figure 46)
+                - RAM Continuous Bidirectional Ramp Mode (p.39, Figure 47)
+                - RAM Continuous Recirculate Mode (p.40, Figure 48)
             base_frequency: float, the unmodulated DDS frequency.
                 0.0 Hz by default. This argument is optional.
             base_phase: float, the unmodulated DDS phase.

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -86,7 +86,9 @@ class RAMProfile:
                 self.pow = dds.turns_to_pow(base_phase)
             case RAMType.POLAR:
                 self.dest = RAM_DEST_POWASF
-                phase, amp = data
+                # Unpack the lsit of tuples into tuples
+                # Zip it again to convert it into 2 lists
+                phase, amp = zip(*data)
                 dds.turns_amplitude_to_ram(phase, amp, ram)
                 self.ftw = dds.frequency_to_ftw(base_frequency)
             case _:

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -28,21 +28,20 @@ class RAMType(Enum):
 
 
 class RAMProfile:
+    """RAM profile is an operation mode that feeds RAM data into the DDS as
+        DDS parameter(s) (frequency/phase/amplitude). At an user-defined time
+        interval, the DDS fetches a new RAM data and updates the selected
+        parameter. See the arguments of the constructor (__init__(..)) to tune
+        the interval, DDS parameter and data selection of the RAM playback.
+
+        All RAM profiles in the same AD9910 has access to the same 1024 x
+        32-bits RAM. There are 1024 entries, each entry occupies 32-bits.
+    """
     RAM_SIZE = 1024
 
     def __init__(self, dds, data, ramp_interval, ram_type, ram_mode,
                  base_frequency=0, base_phase=0, base_amplitude=1.0):
         """Generate a RAM profile to a DDS channel.
-
-            RAM profile is an operation mode that feeds RAM data into the DDS
-            as DDS parameter(s) (frequency/phase/amplitude). At regular time
-            interval, the DDS fetches a new RAM data and updates the selected
-            parameter. See the arguments to tune to interval, DDS parameter
-            and data selection. (See args ramp_interval, ram_type, ram_mode)
-
-            All RAM profiles in the same AD9910 has access to the same 1024 x
-            32-bits RAM. There are 1024 entries, each entry occupies 32-bits.
-
             Unlike single-tone profiles, RAM profiles only specifies a subset
             of parameters. The remaining parameters are specified through the
             FTW/POW/ASF registers instead (See args base_frequency, base_phase,

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -233,7 +233,7 @@ class RAMProfileMap:
 
             Each RAM entry contributes to the slack loss. From experimentation
             and generalization, the first 127 RAM entries each contributes
-            approximately ~60 ns of slack los on average. The rest of the RAM
+            approximately ~60 ns of slack loss on average. The rest of the RAM
             entries each contributes to ~40 ns of slack loss on average.
         """
         # Switch to profile 0 for RAM. This is the default profile.

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -1,5 +1,6 @@
-from artiq.experiment import *
-from artiq.coredevice.ad9910 import *
+from artiq.experiment import kernel
+from artiq.coredevice.ad9910 import RAM_DEST_FTW, RAM_DEST_POW, RAM_DEST_ASF, \
+    RAM_DEST_POWASF
 import numpy as np
 from enum import Enum
 

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -28,9 +28,6 @@ class RAMType(Enum):
 
 
 class RAMProfile:
-    # From AD9910 datasheet:
-    # "The AD9910 makes use of a 1024 × 32-bit RAM."
-    # Each entry occupies 32 bits.
     RAM_SIZE = 1024
 
     def __init__(self, dds, data, ramp_interval, ram_type, ram_mode,
@@ -42,6 +39,9 @@ class RAMProfile:
             interval, the DDS fetches a new RAM data and updates the selected
             parameter. See the arguments to tune to interval, DDS parameter
             and data selection. (See args ramp_interval, ram_type, ram_mode)
+
+            All RAM profiles in the same AD9910 has access to the same 1024 x
+            32-bits RAM. There are 1024 entries, each entry occupies 32-bits.
 
             Unlike single-tone profiles, RAM profiles only specifies a subset
             of parameters. The remaining parameters are specified through the

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -143,8 +143,8 @@ class RAMProfileMap:
         self.cplds = list(cplds)
 
     @kernel
-    def program(self):
-        """Program the RAM profiles to the corresponding AD9910s.
+    def load_ram(self):
+        """Load RAM operation. It initializes the RAM content and profiles.
 
         """
         # Switch to profile 0 for RAM. This is the default profile.

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -1,0 +1,206 @@
+from artiq.experiment import *
+from artiq.coredevice.ad9910 import *
+from jax import JaxExperiment
+import numpy as np
+from enum import Enum
+
+
+__all__ = ["AD9910RAM"]
+
+
+class RAMType(Enum):
+    """The type of data in the RAM.
+
+    Enums:
+        FREQ: Data are treated as frequencies (Hz).
+            The exact frequencies will be played-back.
+        PHASE: Data are treated as phases (turns)
+            Phase modulation will be performed.
+        AMP: Data are treated as amplitudes.
+            Amplitude modulation will be performed.
+        Polar: Data are treated as amplitudes & phase.
+            Polar modulation will be performed.
+    """
+    FREQ = 1
+    PHASE = 2
+    AMP = 3
+    POLAR = 4
+
+
+class RAMProfile:
+    RAM_SIZE = 1024
+
+    def __init__(self, dds, data, ramp_interval, ram_type, ramp_mode,
+                 base_frequency=0, base_phase=0, base_amplitude=0):
+        """Generate a RAM profile to a DDS channel.
+            Include optional parameters based on the "Data Source Priority" of
+            AD9910. See the switch case below to find out which optional
+            parameter is needed.
+
+        Args:
+            dds: The DDS that will playback the RAM profile.
+            data: Data (amplitude, phase, frequencies) to be put into the RAM.
+            ramp_interval: The time interval between each step of the RAM.
+                Note: If possible, keep the interval at a multiple of
+                    4*T_sysclk. T_sysclk is generally 1ns.
+            ram_type: See the RAMType enum.
+            ramp_mode: The playback mode of the RAM. See urukul.py in ARTIQ.
+            base_frequency: (Optional) Unmodulated DDS frequency.
+            base_phase: (Optional) Unmodulated DDS phase.
+            base_amplitude: (Optional) Unmodulated DDS amplitude.
+
+        Raises:
+            NotImplementedError: Unsupported RAM types found.
+        """
+        # Make sure the RAM can hold the entire sequence
+        assert(len(data) <= RAMProfile.RAM_SIZE)
+
+        ram = np.zeros((len(data),), dtype=int)
+        # Avoid contaminating the passed in data list
+        data = data.copy()
+        # SPI transaction of AD9910 mandates the transmission of higher
+        # order words before lower order words
+        # The data is reversed such that the first word shows up first
+        data.reverse()
+
+        # Initialize default values for the FTW, POW, and ASF registers
+        # This is with accordance to set_mu() in AD9910
+        self.ftw, self.pow, self.asf = 0, 0, 0x3fff
+
+        # Encode the FTW, POW, ASF, and raw data en masse
+        match ram_type:
+            case RAMType.FREQ:
+                self.dest = RAM_DEST_FTW
+                dds.frequency_to_ram(data, ram)
+                self.asf = dds.amplitude_to_asf(base_amplitude)
+                self.pow = dds.turns_to_pow(base_phase)
+            case RAMType.PHASE:
+                self.dest = RAM_DEST_POW
+                dds.turns_to_ram(data, ram)
+                self.ftw = dds.frequency_to_ftw(base_frequency)
+                self.asf = dds.amplitude_to_asf(base_amplitude)
+            case RAMType.AMP:
+                self.dest = RAM_DEST_ASF
+                dds.amplitude_to_ram(data, ram)
+                self.ftw = dds.frequency_to_ftw(base_frequency)
+                self.pow = dds.turns_to_pow(base_phase)
+            case RAMType.POLAR:
+                self.dest = RAM_DEST_POWASF
+                phase, amp = data
+                dds.turns_amplitude_to_ram(phase, amp, ram)
+                self.ftw = dds.frequency_to_ftw(base_frequency)
+            case _:
+                raise NotImplementedError
+
+        self.start_addr = 0
+        self.end_addr = len(ram) - 1    # Inclusive
+
+        # Configure ther use of OSK. Note that using different OSK settings for
+        # different channels introduces step swiching latencies
+        if ram_type == RAMType.AMP or ram_type == RAMType.POLAR:
+            # Disable OSK. OSK amplitude as it has a higher priority than RAM.
+            self.osk_enable = 0
+        else:
+            # Enable OSK. There are no other utilizable amplitude data source.
+            self.osk_enable = 1
+
+        # Conversion to list to avoid type mismatch in the kernel
+        self.ram = ram.tolist()
+
+        # Note: Integer conversion may cause inaccuracy
+        self.step = int(ramp_interval * dds.sysclk / 4.0)
+
+        self.ramp_mode = ramp_mode
+
+
+class RAMProfileMap:
+    def __init__(self, core):
+        """Initialize a RAM profile to DDS mapping
+
+        Args:
+            core: The ARTIQ Core instance for time control.
+        """
+        self.ram_profile_map = []
+        self.cplds = []
+        self.core = core
+
+    def append(self, dds, ram_profile):
+        """Append a RAM profile into the builder. In addition, register the
+            CPLDs that have DDSes that playback the RAM profile.
+
+        Args:
+            dds: The DDS that will playback the RAM profile.
+            ram_profile: The RAM profile.
+        """
+        self.ram_profile_map.append((dds, ram_profile))
+
+        # Add the associlated CPLD to the list if not already there.
+        # ARTIQ-Python does not support iterration of a Python builtin set
+        # The workaround is to maintain a list, but convert it into set to
+        # avoid CPLD duplications.
+        cplds = set(self.cplds)
+        cplds.add(dds.cpld)
+        self.cplds = list(cplds)
+
+    @kernel
+    def program(self):
+        """Program the RAM profiles to the corresponding AD9910s.
+
+        """
+        # Switch to profile 0 for RAM. This is the default profile.
+        # Using other profiles for RAM is possible with appropriate parameters
+        # for future AD9910 function calls.
+        for cpld in self.cplds:
+            cpld.set_profile(0)
+
+        for dds, ram_profile in self.ram_profile_map:
+            # Datasheets strongly recommands setting ram_enable=0 before
+            # writing anything to the RAM profiles
+            dds.set_cfr1(ram_enable=0)
+            dds.cpld.io_update.pulse_mu(8)
+
+            # Write RAM profile that corresponds to the DDS
+            dds.set_profile_ram(
+                start=ram_profile.start_addr,
+                end=ram_profile.end_addr,
+                step=ram_profile.step,
+                mode=ram_profile.ramp_mode)
+            dds.cpld.io_update.pulse_mu(8)
+
+            # Program the RAM, break_realtime to avoid RTIOunderflow
+            dds.write_ram(ram_profile.ram)
+            self.core.break_realtime()
+
+            # Alternatively, use dds.set()
+            dds.set_mu(ftw=ram_profile.ftw,
+                       pow_=ram_profile.pow,
+                       asf=ram_profile.asf,
+                       ram_destination=ram_profile.dest)
+
+        # Queue in RAM enable operations to each DDS
+        for dds, ram_profile in self.ram_profile_map:
+            dds.set_cfr1(ram_enable=1,
+                         ram_destination=ram_profile.dest,
+                         osk_enable=ram_profile.osk_enable)
+
+        # Enable the RAM operations using the same I/O update pulse
+        for cpld in self.cplds:
+            cpld.io_update.pulse_mu(8)
+
+
+class AD9910RAM(JaxExperiment):
+    """Base class for experiments that uses the AD9910 RAM
+
+    """
+    @kernel
+    def init_dds(self, dds):
+        """Enable the supplied DDS with 6.0 dB attenuation
+
+        """
+        self.core.break_realtime()
+        dds.init()
+        dds.set_att(6.*dB)
+        dds.cfg_sw(True)
+
+    def run(self):
+        self.kernel_func()

--- a/examples/experiments/ex3_ram_control.py
+++ b/examples/experiments/ex3_ram_control.py
@@ -12,7 +12,7 @@ import numpy as np
 __all__ = ["RAM"]
 
 
-class RAM(AD9910RAM, SinaraEnvironment):
+class RAM(JaxExperiment, SinaraEnvironment):
     """Example experiment generating a DDS amplitude ramp waveform, and a frequency sweeo.
 
     An experiment must first inherit from a base experiment and then inherit an environment.

--- a/examples/experiments/ex3_ram_control.py
+++ b/examples/experiments/ex3_ram_control.py
@@ -91,4 +91,28 @@ class RAM(JaxExperiment, SinaraEnvironment):
         self.init_dds(self.dds2)
         self.init_dds(self.dds3)
 
-        self.profile_map.program()
+        # Prepare a RAM profile & a single-tione profile
+        for dds in [self.dds0, self.dds1, self.dds2, self.dds3]:
+            dds.set(frequency=5*MHz, amplitude=0.2)
+
+        self.profile_map.load_ram()
+        self.profile_map.enable()
+
+        # DDS output sequence:
+        # 1. RAM profiles for 1 ms
+        # 2. Single-tone profiles for 1 ms
+        # 3. RAM profiles for another 1 ms
+        # 4. Single-tone profiles until reset
+        self.profile_map.commit_enable()
+        self.profile_map.disable()
+
+        delay(1*ms)
+        self.profile_map.commit_disable()
+        self.profile_map.enable()
+
+        delay(1*ms)
+        self.profile_map.commit_enable()
+        self.profile_map.disable()
+
+        delay(1*ms)
+        self.profile_map.commit_disable()

--- a/examples/experiments/ex3_ram_control.py
+++ b/examples/experiments/ex3_ram_control.py
@@ -26,9 +26,6 @@ class RAM(JaxExperiment, SinaraEnvironment):
     Change the DDSes and Urukul CPLDs to use different Urukuls and different RF channels.
     Change the numpy generated array to generate a different waveform.
 
-    Generating with an amplitude RAM profile & a non-amplitude RAM profile introduces
-    an approximately 40ns delay.
-
     Before running this experiment, the DDS output should be terminated with a 50 ohm terminator.
     """
     def build(self):

--- a/examples/experiments/ex3_ram_control.py
+++ b/examples/experiments/ex3_ram_control.py
@@ -65,11 +65,18 @@ class RAM(JaxExperiment, SinaraEnvironment):
         self.profile_map.append(self.dds2, ram_profile2)
         self.profile_map.append(self.dds3, ram_profile3)
 
-        # Assign the kernel function here
-        self.kernel_func = self.run_kernel
+    @kernel
+    def init_dds(self, dds):
+        """Enable the supplied DDS with 6.0 dB attenuation
+
+        """
+        self.core.break_realtime()
+        dds.init()
+        dds.set_att(6.*dB)
+        dds.cfg_sw(True)
 
     @kernel
-    def run_kernel(self):
+    def run(self):
         self.core.reset()
         self.core.break_realtime()
 

--- a/examples/experiments/ex3_ram_control.py
+++ b/examples/experiments/ex3_ram_control.py
@@ -41,10 +41,10 @@ class RAM(JaxExperiment, SinaraEnvironment):
 
         # Generate a linearly growing amplitude, in a list
         # When targeting amplitude in RAM, amplitude modulation is performed
-        amp = np.linspace(0.0, 1.0, num=10).tolist()
-        freq = np.linspace(1e6, 100e6, num=10).tolist()
-        phase = [0.2, 0.7]
-        polar = [[0.2, 0.0], [0.7, 0.8]]
+        amp = np.linspace(0.1, 1.0, num=10).tolist()
+        freq = np.linspace(1e6, 10e6, num=10).tolist()
+        phase = np.linspace(0.0, 4.5, num=10).tolist()
+        polar = list(zip(phase, amp))
 
         ram_profile0 = RAMProfile(
             self.dds0, amp, 400*ns, RAMType.AMP, RAM_MODE_CONT_RAMPUP,

--- a/examples/experiments/ex3_ram_control.py
+++ b/examples/experiments/ex3_ram_control.py
@@ -94,7 +94,7 @@ class RAM(JaxExperiment, SinaraEnvironment):
         self.init_dds(self.dds2)
         self.init_dds(self.dds3)
 
-        # Prepare a RAM profile & a single-tione profile
+        # Prepare a RAM profile & a single-tone profile
         for dds in [self.dds0, self.dds1, self.dds2, self.dds3]:
             dds.set(frequency=5*MHz, amplitude=0.2)
 

--- a/examples/experiments/ex3_ram_control.py
+++ b/examples/experiments/ex3_ram_control.py
@@ -13,16 +13,19 @@ __all__ = ["RAM"]
 
 
 class RAM(JaxExperiment, SinaraEnvironment):
-    """Example experiment generating a DDS amplitude ramp waveform, and a frequency sweeo.
+    """Example experiment generating several DDS waveform, controlled by the
+    AD9910 RAM.
 
-    An experiment must first inherit from a base experiment and then inherit an environment.
-    The base experiment defines the self.run() function, and interactions with the RAM
-    profiles.
-    The environment sets up the labrad connection and provides functions for data saving,
-    loading parameters, resetting hardware, etc.
+    The following repetitive waveform are generated:
+    - Channel 0: Amplitude modulation. The DDS amplitude scale factor increments by 0.1 at
+        every step. It increases from 0.1 to 1.0.
+    - Channel 1: Frequency sweep. Increasing DDS frequency from 1 MHz to 10 MHz. The frequency
+        increments 1 MHz every step.
+    - Channel 2: Binary phase modulation. The phase is flipped by 0.5 turns at every step.
+    - Channel 3: Polar modulation. The amplitude is the same as channel 0, and the phase is
+        flipped by 0.5 turns at every step, just like Channel 2.
 
-    This is an experiment generating a repeatitive DDS amplitude ramp, as well as a
-    frequency sweep. To run this experiment, you need to run the "artiq" labrad server.
+    To run this experiment, you need to run the "artiq" labrad server.
     Change the DDSes and Urukul CPLDs to use different Urukuls and different RF channels.
     Change the numpy generated array to generate a different waveform.
 

--- a/examples/experiments/ex3_ram_control.py
+++ b/examples/experiments/ex3_ram_control.py
@@ -1,0 +1,90 @@
+from artiq.experiment import *
+from artiq.coredevice.ad9910 import *
+from jax import SinaraEnvironment, AD9910RAM, RAMType, RAMProfile, RAMProfileMap
+import numpy as np
+
+
+# __all__ in an experiment module should typically only include the experiment class.
+# Specially, it cannot include the base experiment class.
+# ARTIQ discovers experiments by trying to load all objects that are subclasses of
+# artiq.experiment.Experiment. If __all__ includes the base experiment classs,
+# ARTIQ will try to load the base experiment class which results in an error.
+__all__ = ["RAM"]
+
+
+class RAM(AD9910RAM, SinaraEnvironment):
+    """Example experiment generating a DDS amplitude ramp waveform, and a frequency sweeo.
+
+    An experiment must first inherit from a base experiment and then inherit an environment.
+    The base experiment defines the self.run() function, and interactions with the RAM
+    profiles.
+    The environment sets up the labrad connection and provides functions for data saving,
+    loading parameters, resetting hardware, etc.
+
+    This is an experiment generating a repeatitive DDS amplitude ramp, as well as a
+    frequency sweep. To run this experiment, you need to run the "artiq" labrad server.
+    Change the DDSes and Urukul CPLDs to use different Urukuls and different RF channels.
+    Change the numpy generated array to generate a different waveform.
+
+    Generating with an amplitude RAM profile & a non-amplitude RAM profile introduces
+    an approximately 40ns delay.
+
+    Before running this experiment, the DDS output should be terminated with a 50 ohm terminator.
+    """
+    def build(self):
+        super().build()  # Calls JaxExperiment.build(), which calls SinaraEnvironment.build()
+        self.cpld = self.get_device("urukul0_cpld")
+        self.dds0 = self.get_device("urukul0_ch0")
+        self.dds1 = self.get_device("urukul0_ch1")
+        self.dds2 = self.get_device("urukul0_ch2")
+        self.dds3 = self.get_device("urukul0_ch3")
+
+    def prepare(self):
+        super().prepare()  # Calls JaxExperiment.prepare(), which calls SinaraEnvironment.prepare()
+
+        # Generate a linearly growing amplitude, in a list
+        # When targeting amplitude in RAM, amplitude modulation is performed
+        amp = np.linspace(0.0, 1.0, num=10).tolist()
+        freq = np.linspace(1e6, 100e6, num=10).tolist()
+        phase = [0.2, 0.7]
+        polar = [[0.2, 0.0], [0.7, 0.8]]
+
+        ram_profile0 = RAMProfile(
+            self.dds0, amp, 400*ns, RAMType.AMP, RAM_MODE_CONT_RAMPUP,
+            base_frequency=100*MHz)
+        ram_profile1 = RAMProfile(
+            self.dds1, freq, 400*ns, RAMType.FREQ, RAM_MODE_CONT_RAMPUP,
+            base_amplitude=1.0)
+        ram_profile2 = RAMProfile(
+            self.dds2, phase, 400*ns, RAMType.PHASE, RAM_MODE_CONT_RAMPUP,
+            base_frequency=100*MHz, base_amplitude=1.0)
+        ram_profile3 = RAMProfile(
+            self.dds3, polar, 400*ns, RAMType.POLAR, RAM_MODE_CONT_RAMPUP,
+            base_frequency=100*MHz, base_amplitude=1.0)
+
+        self.profile_map = RAMProfileMap(self.core)
+        self.profile_map.append(self.dds1, ram_profile0)
+        self.profile_map.append(self.dds0, ram_profile1)
+        self.profile_map.append(self.dds2, ram_profile2)
+        self.profile_map.append(self.dds3, ram_profile3)
+
+        # Assign the kernel function here
+        self.kernel_func = self.run_kernel
+
+    @kernel
+    def run_kernel(self):
+        self.core.reset()
+        self.core.break_realtime()
+
+        # Initialization of the Urukul and DDS channels
+        # A few things must be done to observe the waveform before playing with the RAM:
+        #   1. Textbook init(), see ARTIQ API/examples.
+        #   2. Turn on the RF switches and give appropriate attenuations.
+        self.cpld.init()
+
+        self.init_dds(self.dds0)
+        self.init_dds(self.dds1)
+        self.init_dds(self.dds2)
+        self.init_dds(self.dds3)
+
+        self.profile_map.program()

--- a/examples/experiments/ex3_ram_control.py
+++ b/examples/experiments/ex3_ram_control.py
@@ -63,8 +63,8 @@ class RAM(JaxExperiment, SinaraEnvironment):
             base_frequency=100*MHz, base_amplitude=1.0)
 
         self.profile_map = RAMProfileMap(self.core)
-        self.profile_map.append(self.dds1, ram_profile0)
-        self.profile_map.append(self.dds0, ram_profile1)
+        self.profile_map.append(self.dds0, ram_profile0)
+        self.profile_map.append(self.dds1, ram_profile1)
         self.profile_map.append(self.dds2, ram_profile2)
         self.profile_map.append(self.dds3, ram_profile3)
 

--- a/examples/experiments/ex3_ram_control.py
+++ b/examples/experiments/ex3_ram_control.py
@@ -1,6 +1,6 @@
 from artiq.experiment import *
 from artiq.coredevice.ad9910 import *
-from jax import SinaraEnvironment, AD9910RAM, RAMType, RAMProfile, RAMProfileMap
+from jax import SinaraEnvironment, RAMType, RAMProfile, RAMProfileMap, JaxExperiment
 import numpy as np
 
 

--- a/examples/experiments/ex3_ram_control.py
+++ b/examples/experiments/ex3_ram_control.py
@@ -99,23 +99,29 @@ class RAM(JaxExperiment, SinaraEnvironment):
             dds.set(frequency=5*MHz, amplitude=0.2)
 
         self.profile_map.load_ram()
-        self.profile_map.enable()
 
         # DDS output sequence:
-        # 1. RAM profiles for 1 ms
-        # 2. Single-tone profiles for 1 ms
-        # 3. RAM profiles for another 1 ms
+        # 1. RAM profiles for 10 us
+        # 2. Single-tone profiles for 10 us
+        # 3. RAM profiles for another 10 us
         # 4. Single-tone profiles until reset
+
+        self.profile_map.enable()
+        # Record time right before commit
+        now = now_mu()
         self.profile_map.commit_enable()
         self.profile_map.disable()
 
-        delay(1*ms)
+        now += self.core.seconds_to_mu(10*us)
+        at_mu(now)
         self.profile_map.commit_disable()
         self.profile_map.enable()
 
-        delay(1*ms)
+        now += self.core.seconds_to_mu(10*us)
+        at_mu(now)
         self.profile_map.commit_enable()
         self.profile_map.disable()
 
-        delay(1*ms)
+        now += self.core.seconds_to_mu(10*us)
+        at_mu(now)
         self.profile_map.commit_disable()


### PR DESCRIPTION
As stated in the title.

~~The `AD9910RAM` class acts as a base class of a generic RAM control experiment, alongside other structures in the `ad9910_ram.py` file.~~
RAM mode control implemented using a combination of classes in `ad9910_ram.py`.
`ex3_ram_control.py` demonstrates how to use it.

Edit: Here's the data source priority table of AD9910. I'm putting it here so we get to reference it on the thread.
![image](https://user-images.githubusercontent.com/54844539/210006161-011a21f2-6b5b-4017-937a-139ca697534d.png)
