### PR TITLE
fixes pyqtgraph imports

### DIFF
--- a/util/ui/fast_plot_trace.py
+++ b/util/ui/fast_plot_trace.py
@@ -3,7 +3,7 @@ import pyqtgraph as _pg
 from PyQt5 import QtCore
 
 
-class _PlotPath(_pg.QtGui.QGraphicsPathItem):
+class _PlotPath(_pg.QtWidgets.QGraphicsPathItem):
     """Generates a path for x-y plotting data.
 
     Replaces the expensive work of plotting data by plotting a path. When plotting a large dataset,


### PR DESCRIPTION
There was probably some qt4 compatibility code removed in pyqtgraph so this no longer works. As all of our lab computers runs pyqt5 it should not be an issue.

pyqtgraph 0.12+ needs this change in order to work