### PR TITLE
Jep/add arg ram profile nodwellhigh

### DIFF
--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -107,7 +107,7 @@ class RAMProfile:
     """
     RAM_SIZE = 1024
 
-    def __init__(self, dds, data, ramp_interval, ram_type, ram_mode):
+    def __init__(self, dds, data, ramp_interval, ram_type, ram_mode, dwell_end=1):
         # Make sure the RAM can hold the entire sequence
         if len(data) > RAMProfile.RAM_SIZE:
             raise ValueError("Data size exceeds the RAM capacity")
@@ -148,6 +148,8 @@ class RAMProfile:
         self.step = int(ramp_interval * dds.sysclk / 4.0)
         self.ram_mode = ram_mode
         self.ram_type = ram_type
+
+        self.nodwell_high = int(not dwell_end)
 
 
 class RAMProfileMap:
@@ -221,6 +223,7 @@ class RAMProfileMap:
                 start=ram_profile.start_addr,
                 end=ram_profile.end_addr,
                 step=ram_profile.step,
+                nodwell_high=ram_profile.nodwell_high,
                 mode=ram_profile.ram_mode)
             dds.cpld.io_update.pulse_mu(8)
 

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -60,7 +60,8 @@ class RAMProfile:
         step: int, the number of sysclk cycles per RAM step.
         ram_mode: int, the playback mode of the RAM.
         ram_type: RAMType, the type of RAM.
-        nodwell_high: No-dwell high bit (default: 0, see AD9910 documentation)
+        nodwell_high: No-dwell high bit (default: 0, see AD9910 documentation).
+        Ignored except for in RAM Ramp-Up Mode.
 
     Args:
         dds: AD9910, the DDS that will playback the RAM profile.
@@ -102,7 +103,8 @@ class RAMProfile:
             - RAM Bidirectional Ramp Mode (p.38, Figure 46)
             - RAM Continuous Bidirectional Ramp Mode (p.39, Figure 47)
             - RAM Continuous Recirculate Mode (p.40, Figure 48)
-        dwell_end: negated no-dwell high bit (default: 1).
+        dwell_end: negated no-dwell high bit (default: 1). Ignored except for in
+        RAM Ramp-Up Mode.
 
     Raises:
         ValueError: Unsupported RAM configuration found.

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -111,7 +111,7 @@ class RAMProfile:
     """
     RAM_SIZE = 1024
 
-    def __init__(self, dds, data, ramp_interval, ram_type, ram_mode, dwell_end=1):
+    def __init__(self, dds, data, ramp_interval, ram_type, ram_mode, dwell_end=True):
         # Make sure the RAM can hold the entire sequence
         if len(data) > RAMProfile.RAM_SIZE:
             raise ValueError("Data size exceeds the RAM capacity")

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -103,8 +103,10 @@ class RAMProfile:
             - RAM Bidirectional Ramp Mode (p.38, Figure 46)
             - RAM Continuous Bidirectional Ramp Mode (p.39, Figure 47)
             - RAM Continuous Recirculate Mode (p.40, Figure 48)
-        dwell_end: negated no-dwell high bit (default: 1). Ignored except for in
-        RAM Ramp-Up Mode.
+        dwell_end: bool. If true, the RAM halts when the last data is reached.
+            Otherwise, the RAM jumps back to the first data and halts after the
+            last data is reached. Ignored except in RAM Ramp-Up Mode. Defaults
+            to True.
 
     Raises:
         ValueError: Unsupported RAM configuration found.

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -60,8 +60,8 @@ class RAMProfile:
         step: int, the number of sysclk cycles per RAM step.
         ram_mode: int, the playback mode of the RAM.
         ram_type: RAMType, the type of RAM.
-        nodwell_high: No-dwell high bit (default: 0, see AD9910 documentation).
-        Ignored except for in RAM Ramp-Up Mode.
+        nodwell_high: int, the no-dwell high bit. Ignored except in RAM Ramp-Up
+            Mode. Defaults to 0 (See AD9910 documentation).
 
     Args:
         dds: AD9910, the DDS that will playback the RAM profile.

--- a/base/experiments/ad9910_ram.py
+++ b/base/experiments/ad9910_ram.py
@@ -60,6 +60,7 @@ class RAMProfile:
         step: int, the number of sysclk cycles per RAM step.
         ram_mode: int, the playback mode of the RAM.
         ram_type: RAMType, the type of RAM.
+        nodwell_high: No-dwell high bit (default: 0, see AD9910 documentation)
 
     Args:
         dds: AD9910, the DDS that will playback the RAM profile.
@@ -101,6 +102,7 @@ class RAMProfile:
             - RAM Bidirectional Ramp Mode (p.38, Figure 46)
             - RAM Continuous Bidirectional Ramp Mode (p.39, Figure 47)
             - RAM Continuous Recirculate Mode (p.40, Figure 48)
+        dwell_end: negated no-dwell high bit (default: 1).
 
     Raises:
         ValueError: Unsupported RAM configuration found.


### PR DESCRIPTION
Added argument to `RAMProfile` to control `nodwell_high` bit used in `ad9910.set_profile_ram`.

Added setting `nodwell_high` argument of `set_profile_ram` called in `ad9910_ram.RAMProfileMap.load_ram`.

Noted in docstring that `nodwell_high` bit is only referenced for `mode=RAM_MODE_RAMPUP`.